### PR TITLE
Add 2026/worldcup.squads.json (official FIFA squads)

### DIFF
--- a/2026/worldcup.squads.json
+++ b/2026/worldcup.squads.json
@@ -1,0 +1,7808 @@
+[
+    {
+        "name": "Czech Republic",
+        "fifa_code": "CZE",
+        "group": "A",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Matěj Kovář",
+                "date_of_birth": "2000-05-17"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "David Zima",
+                "date_of_birth": "2000-11-08"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Tomáš Holeš",
+                "date_of_birth": "1993-03-31"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Robin Hranáč",
+                "date_of_birth": "2000-01-29"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Vladimír Coufal",
+                "date_of_birth": "1992-08-22"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Štěpán Chaloupek",
+                "date_of_birth": "2003-03-08"
+            },
+            {
+                "number": 7,
+                "pos": "DF",
+                "name": "Ladislav Krejčí",
+                "date_of_birth": "1999-04-20"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Vladimír Darida",
+                "date_of_birth": "1990-08-08"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Adam Hložek",
+                "date_of_birth": "2002-07-25"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Patrik Schick",
+                "date_of_birth": "1996-01-24"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Jan Kuchta",
+                "date_of_birth": "1997-01-08"
+            },
+            {
+                "number": 12,
+                "pos": "MF",
+                "name": "Lukáš Červ",
+                "date_of_birth": "2001-04-10"
+            },
+            {
+                "number": 13,
+                "pos": "FW",
+                "name": "Mojmír Chytil",
+                "date_of_birth": "1999-04-29"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "David Jurásek",
+                "date_of_birth": "2000-08-07"
+            },
+            {
+                "number": 15,
+                "pos": "FW",
+                "name": "Pavel Šulc",
+                "date_of_birth": "2000-12-29"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Jindřich Staněk",
+                "date_of_birth": "1996-04-27"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Lukáš Provod",
+                "date_of_birth": "1996-10-23"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Michal Sadílek",
+                "date_of_birth": "1999-05-31"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Tomáš Chorý",
+                "date_of_birth": "1995-01-26"
+            },
+            {
+                "number": 20,
+                "pos": "DF",
+                "name": "Jaroslav Zelený",
+                "date_of_birth": "1992-08-20"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "David Douděra",
+                "date_of_birth": "1998-05-31"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Tomáš Souček",
+                "date_of_birth": "1995-02-27"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Lukáš Horníček",
+                "date_of_birth": "2002-07-13"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Alexandr Sojka",
+                "date_of_birth": "2003-04-02"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Hugo Sochůrek",
+                "date_of_birth": "2008-06-07"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Denis Višinský",
+                "date_of_birth": "2003-03-21"
+            }
+        ]
+    },
+    {
+        "name": "Mexico",
+        "fifa_code": "MEX",
+        "group": "A",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Raúl Rangel",
+                "date_of_birth": "2000-02-25"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Jorge Sánchez",
+                "date_of_birth": "1997-12-10"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "César Montes",
+                "date_of_birth": "1997-02-24"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Edson Álvarez",
+                "date_of_birth": "1997-10-24"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Johan Vásquez",
+                "date_of_birth": "1998-10-22"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Érik Lira",
+                "date_of_birth": "2000-05-08"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Luis Romo",
+                "date_of_birth": "1995-06-05"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Álvaro Fidalgo",
+                "date_of_birth": "1997-04-09"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Raúl Jiménez",
+                "date_of_birth": "1991-05-05"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Alexis Vega",
+                "date_of_birth": "1997-11-25"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Santiago Giménez",
+                "date_of_birth": "2001-04-18"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Carlos Acevedo",
+                "date_of_birth": "1996-04-19"
+            },
+            {
+                "number": 13,
+                "pos": "GK",
+                "name": "Guillermo Ochoa",
+                "date_of_birth": "1985-07-13"
+            },
+            {
+                "number": 14,
+                "pos": "FW",
+                "name": "Armando González",
+                "date_of_birth": "2003-04-20"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Israel Reyes",
+                "date_of_birth": "2000-05-23"
+            },
+            {
+                "number": 16,
+                "pos": "FW",
+                "name": "Julián Quiñones",
+                "date_of_birth": "1997-03-24"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Orbelín Pineda",
+                "date_of_birth": "1996-03-24"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Obed Vargas",
+                "date_of_birth": "2005-08-05"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Gilberto Mora",
+                "date_of_birth": "2008-10-14"
+            },
+            {
+                "number": 20,
+                "pos": "DF",
+                "name": "Mateo Chávez",
+                "date_of_birth": "2004-05-12"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "César Huerta",
+                "date_of_birth": "2000-12-03"
+            },
+            {
+                "number": 22,
+                "pos": "FW",
+                "name": "Guillermo Martínez",
+                "date_of_birth": "1995-03-15"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Jesús Gallardo",
+                "date_of_birth": "1994-08-15"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Luis Chávez",
+                "date_of_birth": "1996-01-15"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Roberto Alvarado",
+                "date_of_birth": "1998-09-07"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Brian Gutiérrez",
+                "date_of_birth": "2003-06-17"
+            }
+        ]
+    },
+    {
+        "name": "South Africa",
+        "fifa_code": "RSA",
+        "group": "A",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Ronwen Williams",
+                "date_of_birth": "1992-01-21"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Thabang Matuludi",
+                "date_of_birth": "1999-01-14"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Khulumani Ndamane",
+                "date_of_birth": "2004-02-05"
+            },
+            {
+                "number": 4,
+                "pos": "MF",
+                "name": "Teboho Mokoena",
+                "date_of_birth": "1997-01-24"
+            },
+            {
+                "number": 5,
+                "pos": "MF",
+                "name": "Thalente Mbatha",
+                "date_of_birth": "2000-03-06"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Aubrey Modiba",
+                "date_of_birth": "1995-07-22"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Oswin Appollis",
+                "date_of_birth": "2001-08-25"
+            },
+            {
+                "number": 8,
+                "pos": "FW",
+                "name": "Tshepang Moremi",
+                "date_of_birth": "2000-10-02"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Lyle Foster",
+                "date_of_birth": "2000-09-03"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Relebohile Mofokeng",
+                "date_of_birth": "2004-10-23"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Themba Zwane",
+                "date_of_birth": "1989-08-03"
+            },
+            {
+                "number": 12,
+                "pos": "FW",
+                "name": "Thapelo Maseko",
+                "date_of_birth": "2003-11-11"
+            },
+            {
+                "number": 13,
+                "pos": "MF",
+                "name": "Sphephelo Sithole",
+                "date_of_birth": "1999-03-03"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Mbekezeli Mbokazi",
+                "date_of_birth": "2005-09-19"
+            },
+            {
+                "number": 15,
+                "pos": "FW",
+                "name": "Iqraam Rayners",
+                "date_of_birth": "1995-12-19"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Sipho Chaine",
+                "date_of_birth": "1996-12-14"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Evidence Makgopa",
+                "date_of_birth": "2000-06-05"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Samukele Kabini",
+                "date_of_birth": "2004-03-15"
+            },
+            {
+                "number": 19,
+                "pos": "DF",
+                "name": "Nkosinathi Sibisi",
+                "date_of_birth": "1995-09-22"
+            },
+            {
+                "number": 20,
+                "pos": "DF",
+                "name": "Khuliso Mudau",
+                "date_of_birth": "1995-04-26"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Ime Okon",
+                "date_of_birth": "2004-02-20"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Ricardo Goss",
+                "date_of_birth": "1994-04-02"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Jayden Adams",
+                "date_of_birth": "2001-05-05"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Olwethu Makhanya",
+                "date_of_birth": "2004-04-30"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Kamogelo Sebelebele",
+                "date_of_birth": "2002-07-21"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Bradley Cross",
+                "date_of_birth": "2001-01-30"
+            }
+        ]
+    },
+    {
+        "name": "South Korea",
+        "fifa_code": "KOR",
+        "group": "A",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Kim Seung-gyu",
+                "date_of_birth": "1990-09-30"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Lee Han-beom",
+                "date_of_birth": "2002-06-17"
+            },
+            {
+                "number": 3,
+                "pos": "MF",
+                "name": "Lee Gi-hyuk",
+                "date_of_birth": "2000-07-07"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Kim Min-jae",
+                "date_of_birth": "1996-11-15"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Kim Tae-hyeon",
+                "date_of_birth": "2000-09-17"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Hwang In-beom",
+                "date_of_birth": "1996-09-20"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Son Heung-min",
+                "date_of_birth": "1992-07-08"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Paik Seung-ho",
+                "date_of_birth": "1997-03-17"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Cho Gue-sung",
+                "date_of_birth": "1998-01-25"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Lee Jae-sung",
+                "date_of_birth": "1992-08-10"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Hwang Hee-chan",
+                "date_of_birth": "1996-01-26"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Song Bum-keun",
+                "date_of_birth": "1997-10-15"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Lee Tae-seok",
+                "date_of_birth": "2002-07-28"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Cho Wi-je",
+                "date_of_birth": "2001-08-25"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Kim Moon-hwan",
+                "date_of_birth": "1995-08-01"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Park Jin-seob",
+                "date_of_birth": "1995-10-23"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Bae Jun-ho",
+                "date_of_birth": "2003-08-21"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Oh Hyeon-gyu",
+                "date_of_birth": "2001-04-12"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Lee Kang-in",
+                "date_of_birth": "2001-02-19"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Yang Hyun-jun",
+                "date_of_birth": "2002-05-25"
+            },
+            {
+                "number": 21,
+                "pos": "GK",
+                "name": "Jo Hyeon-woo",
+                "date_of_birth": "1991-09-25"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Seol Young-woo",
+                "date_of_birth": "1998-12-05"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Jens Castrop",
+                "date_of_birth": "2003-07-29"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Kim Jin-gyu",
+                "date_of_birth": "1997-02-24"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Eom Ji-sung",
+                "date_of_birth": "2002-05-09"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Lee Dong-gyeong",
+                "date_of_birth": "1997-09-20"
+            }
+        ]
+    },
+    {
+        "name": "Bosnia and Herzegovina",
+        "fifa_code": "BIH",
+        "group": "B",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Nikola Vasilj",
+                "date_of_birth": "1995-12-02"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Nihad Mujakić",
+                "date_of_birth": "1998-04-15"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Dennis Hadžikadunić",
+                "date_of_birth": "1998-07-09"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Tarik Muharemović",
+                "date_of_birth": "2003-02-28"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Sead Kolašinac",
+                "date_of_birth": "1993-06-20"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Benjamin Tahirović",
+                "date_of_birth": "2003-03-03"
+            },
+            {
+                "number": 7,
+                "pos": "DF",
+                "name": "Amar Dedić",
+                "date_of_birth": "2002-08-18"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Armin Gigović",
+                "date_of_birth": "2002-04-06"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Samed Baždar",
+                "date_of_birth": "2004-01-31"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Ermedin Demirović",
+                "date_of_birth": "1998-03-25"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Edin Džeko",
+                "date_of_birth": "1986-03-17"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Mladen Jurkas",
+                "date_of_birth": "2007-10-07"
+            },
+            {
+                "number": 13,
+                "pos": "MF",
+                "name": "Ivan Bašić",
+                "date_of_birth": "2002-04-30"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Ivan Šunjić",
+                "date_of_birth": "1996-10-09"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Amar Memić",
+                "date_of_birth": "2001-01-20"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Amir Hadžiahmetović",
+                "date_of_birth": "1997-03-08"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Dženis Burnić",
+                "date_of_birth": "1998-05-22"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Nikola Katić",
+                "date_of_birth": "1996-10-10"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Kerim Alajbegović",
+                "date_of_birth": "2007-09-21"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Esmir Bajraktarević",
+                "date_of_birth": "2005-03-10"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Stjepan Radeljić",
+                "date_of_birth": "1997-09-05"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Martin Zlomislić",
+                "date_of_birth": "1998-08-16"
+            },
+            {
+                "number": 23,
+                "pos": "FW",
+                "name": "Haris Tabaković",
+                "date_of_birth": "1994-06-20"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Nidal Čelik",
+                "date_of_birth": "2006-07-17"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Jovo Lukić",
+                "date_of_birth": "1998-11-28"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Ermin Mahmić",
+                "date_of_birth": "2005-03-14"
+            }
+        ]
+    },
+    {
+        "name": "Canada",
+        "fifa_code": "CAN",
+        "group": "B",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Dayne St. Clair",
+                "date_of_birth": "1997-05-09"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Alistair Johnston",
+                "date_of_birth": "1998-10-08"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Alfie Jones",
+                "date_of_birth": "1997-10-07"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Luc de Fougerolles",
+                "date_of_birth": "2005-10-12"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Joel Waterman",
+                "date_of_birth": "1996-01-24"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Mathieu Choinière",
+                "date_of_birth": "1999-02-07"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Stephen Eustáquio",
+                "date_of_birth": "1996-12-21"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Ismaël Koné",
+                "date_of_birth": "2002-06-16"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Cyle Larin",
+                "date_of_birth": "1995-04-17"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Jonathan David",
+                "date_of_birth": "2000-01-14"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Liam Millar",
+                "date_of_birth": "1999-09-27"
+            },
+            {
+                "number": 12,
+                "pos": "FW",
+                "name": "Tani Oluwaseyi",
+                "date_of_birth": "2000-05-15"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Derek Cornelius",
+                "date_of_birth": "1997-11-25"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Jacob Shaffelburg",
+                "date_of_birth": "1999-11-26"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Moïse Bombito",
+                "date_of_birth": "2000-03-30"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Maxime Crépeau",
+                "date_of_birth": "1994-05-11"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Tajon Buchanan",
+                "date_of_birth": "1999-02-08"
+            },
+            {
+                "number": 18,
+                "pos": "GK",
+                "name": "Owen Goodman",
+                "date_of_birth": "2003-11-27"
+            },
+            {
+                "number": 19,
+                "pos": "DF",
+                "name": "Alphonso Davies",
+                "date_of_birth": "2000-11-02"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Ali Ahmed",
+                "date_of_birth": "2000-10-10"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Jonathan Osorio",
+                "date_of_birth": "1992-06-12"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Richie Laryea",
+                "date_of_birth": "1995-01-07"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Niko Sigur",
+                "date_of_birth": "2003-09-09"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Promise David",
+                "date_of_birth": "2001-07-03"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Nathan Saliba",
+                "date_of_birth": "2004-02-07"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Jayden Nelson",
+                "date_of_birth": "2002-02-07"
+            }
+        ]
+    },
+    {
+        "name": "Qatar",
+        "fifa_code": "QAT",
+        "group": "B",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Mahmud Abunada",
+                "date_of_birth": "2000-02-05"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Pedro Miguel",
+                "date_of_birth": "1990-08-06"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Lucas Mendes",
+                "date_of_birth": "1990-07-03"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Issa Laye",
+                "date_of_birth": "1997-12-22"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Jassem Gaber",
+                "date_of_birth": "2002-02-20"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Abdulaziz Hatem",
+                "date_of_birth": "1990-01-01"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Ahmed Alaaeldin",
+                "date_of_birth": "1993-01-31"
+            },
+            {
+                "number": 8,
+                "pos": "FW",
+                "name": "Edmilson Junior",
+                "date_of_birth": "1994-08-19"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Mohammed Muntari",
+                "date_of_birth": "1993-12-20"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Hassan Al-Haydos",
+                "date_of_birth": "1990-12-11"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Akram Afif",
+                "date_of_birth": "1996-11-18"
+            },
+            {
+                "number": 12,
+                "pos": "MF",
+                "name": "Karim Boudiaf",
+                "date_of_birth": "1990-09-16"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Ayoub Al-Oui",
+                "date_of_birth": "2005-03-11"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Homam Ahmed",
+                "date_of_birth": "1999-08-25"
+            },
+            {
+                "number": 15,
+                "pos": "FW",
+                "name": "Yusuf Abdurisag",
+                "date_of_birth": "1999-08-06"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Boualem Khoukhi",
+                "date_of_birth": "1990-07-09"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Ahmed Al-Ganehi",
+                "date_of_birth": "2000-09-22"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Sultan Al-Brake",
+                "date_of_birth": "1996-04-07"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Almoez Ali",
+                "date_of_birth": "1996-08-19"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Ahmed Fathy",
+                "date_of_birth": "1993-01-25"
+            },
+            {
+                "number": 21,
+                "pos": "GK",
+                "name": "Salah Zakaria",
+                "date_of_birth": "1999-04-24"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Meshaal Barsham",
+                "date_of_birth": "1998-02-14"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Assim Madibo",
+                "date_of_birth": "1996-10-22"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Tahsin Jamshid",
+                "date_of_birth": "2006-06-16"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Al-Hashmi Al-Hussain",
+                "date_of_birth": "2003-08-15"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Mohamed Manai",
+                "date_of_birth": "2002-10-25"
+            }
+        ]
+    },
+    {
+        "name": "Switzerland",
+        "fifa_code": "SUI",
+        "group": "B",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Gregor Kobel",
+                "date_of_birth": "1997-12-06"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Miro Muheim",
+                "date_of_birth": "1998-03-24"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Silvan Widmer",
+                "date_of_birth": "1993-03-05"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Nico Elvedi",
+                "date_of_birth": "1996-09-30"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Manuel Akanji",
+                "date_of_birth": "1995-07-19"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Denis Zakaria",
+                "date_of_birth": "1996-11-20"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Breel Embolo",
+                "date_of_birth": "1997-02-14"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Remo Freuler",
+                "date_of_birth": "1992-04-15"
+            },
+            {
+                "number": 9,
+                "pos": "MF",
+                "name": "Johan Manzambi",
+                "date_of_birth": "2005-10-14"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Granit Xhaka",
+                "date_of_birth": "1992-09-27"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Dan Ndoye",
+                "date_of_birth": "2000-10-25"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Yvon Mvogo",
+                "date_of_birth": "1994-06-06"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Ricardo Rodriguez",
+                "date_of_birth": "1992-08-25"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Ardon Jashari",
+                "date_of_birth": "2002-07-30"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Djibril Sow",
+                "date_of_birth": "1997-02-06"
+            },
+            {
+                "number": 16,
+                "pos": "FW",
+                "name": "Christian Fassnacht",
+                "date_of_birth": "1993-11-11"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Rubén Vargas",
+                "date_of_birth": "1998-08-05"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Eray Cömert",
+                "date_of_birth": "1998-02-04"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Noah Okafor",
+                "date_of_birth": "2000-05-24"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Michel Aebischer",
+                "date_of_birth": "1997-01-06"
+            },
+            {
+                "number": 21,
+                "pos": "GK",
+                "name": "Marvin Keller",
+                "date_of_birth": "2002-07-03"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Fabian Rieder",
+                "date_of_birth": "2002-02-16"
+            },
+            {
+                "number": 23,
+                "pos": "FW",
+                "name": "Zeki Amdouni",
+                "date_of_birth": "2000-12-04"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Aurèle Amenda",
+                "date_of_birth": "2003-07-31"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Luca Jaquez",
+                "date_of_birth": "2003-06-02"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Cedric Itten",
+                "date_of_birth": "1996-12-27"
+            }
+        ]
+    },
+    {
+        "name": "Brazil",
+        "fifa_code": "BRA",
+        "group": "C",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Alisson",
+                "date_of_birth": "1992-10-02"
+            },
+            {
+                "number": 2,
+                "pos": "MF",
+                "name": "Éderson Silva",
+                "date_of_birth": "1999-07-07"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Gabriel Magalhães",
+                "date_of_birth": "1997-12-19"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Marquinhos",
+                "date_of_birth": "1994-05-14"
+            },
+            {
+                "number": 5,
+                "pos": "MF",
+                "name": "Casemiro",
+                "date_of_birth": "1992-02-23"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Alex Sandro",
+                "date_of_birth": "1991-01-26"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Vinícius Júnior",
+                "date_of_birth": "2000-07-12"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Bruno Guimarães",
+                "date_of_birth": "1997-11-16"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Matheus Cunha",
+                "date_of_birth": "1999-05-27"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Neymar",
+                "date_of_birth": "1992-02-05"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Raphinha",
+                "date_of_birth": "1996-12-14"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Weverton",
+                "date_of_birth": "1987-12-13"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Danilo Luiz",
+                "date_of_birth": "1991-07-15"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Bremer",
+                "date_of_birth": "1997-03-18"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Léo Pereira",
+                "date_of_birth": "1996-01-31"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Douglas Santos",
+                "date_of_birth": "1994-03-22"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Fabinho",
+                "date_of_birth": "1993-10-23"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Danilo Santos",
+                "date_of_birth": "2001-04-29"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Endrick",
+                "date_of_birth": "2006-07-21"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Lucas Paquetá",
+                "date_of_birth": "1997-08-27"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Luiz Henrique",
+                "date_of_birth": "2001-01-02"
+            },
+            {
+                "number": 22,
+                "pos": "FW",
+                "name": "Gabriel Martinelli",
+                "date_of_birth": "2001-06-18"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Ederson Moraes",
+                "date_of_birth": "1993-08-17"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Roger Ibañez",
+                "date_of_birth": "1998-11-23"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Igor Thiago",
+                "date_of_birth": "2001-06-26"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Rayan",
+                "date_of_birth": "2006-08-03"
+            }
+        ]
+    },
+    {
+        "name": "Haiti",
+        "fifa_code": "HAI",
+        "group": "C",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Johny Placide",
+                "date_of_birth": "1988-01-29"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Carlens Arcus",
+                "date_of_birth": "1996-06-28"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Keeto Thermoncy",
+                "date_of_birth": "2006-03-29"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Ricardo Adé",
+                "date_of_birth": "1990-05-21"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Hannes Delcroix",
+                "date_of_birth": "1999-02-28"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Carl Sainté",
+                "date_of_birth": "2002-08-09"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Derrick Etienne Jr.",
+                "date_of_birth": "1996-11-25"
+            },
+            {
+                "number": 8,
+                "pos": "DF",
+                "name": "Martin Expérience",
+                "date_of_birth": "1999-03-09"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Duckens Nazon",
+                "date_of_birth": "1994-04-07"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Jean-Ricner Bellegarde",
+                "date_of_birth": "1998-06-27"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Louicius Deedson",
+                "date_of_birth": "2001-02-11"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Alexandre Pierre",
+                "date_of_birth": "2001-02-25"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Duke Lacroix",
+                "date_of_birth": "1993-10-14"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Leverton Pierre",
+                "date_of_birth": "1998-03-09"
+            },
+            {
+                "number": 15,
+                "pos": "FW",
+                "name": "Ruben Providence",
+                "date_of_birth": "2001-07-07"
+            },
+            {
+                "number": 16,
+                "pos": "FW",
+                "name": "Lenny Joseph",
+                "date_of_birth": "2000-10-12"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Danley Jean Jacques",
+                "date_of_birth": "2000-05-20"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Wilson Isidor",
+                "date_of_birth": "2000-08-27"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Yassin Fortuné",
+                "date_of_birth": "1999-01-30"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Frantzdy Pierrot",
+                "date_of_birth": "1995-03-29"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Josué Casimir",
+                "date_of_birth": "2001-09-24"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Jean-Kévin Duverne",
+                "date_of_birth": "1997-07-12"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Josué Duverger",
+                "date_of_birth": "2000-04-27"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Wilguens Paugain",
+                "date_of_birth": "2001-08-24"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Dominique Simon",
+                "date_of_birth": "2000-07-29"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Woodensky Pierre",
+                "date_of_birth": "2004-12-30"
+            }
+        ]
+    },
+    {
+        "name": "Morocco",
+        "fifa_code": "MAR",
+        "group": "C",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Yassine Bounou",
+                "date_of_birth": "1991-04-05"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Achraf Hakimi",
+                "date_of_birth": "1998-11-04"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Noussair Mazraoui",
+                "date_of_birth": "1997-11-14"
+            },
+            {
+                "number": 4,
+                "pos": "MF",
+                "name": "Sofyan Amrabat",
+                "date_of_birth": "1996-08-21"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Nayef Aguerd",
+                "date_of_birth": "1996-03-30"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Ayyoub Bouaddi",
+                "date_of_birth": "2007-10-02"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Chemsdine Talbi",
+                "date_of_birth": "2005-05-09"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Azzedine Ounahi",
+                "date_of_birth": "2000-04-19"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Soufiane Rahimi",
+                "date_of_birth": "1996-06-02"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Brahim Díaz",
+                "date_of_birth": "1999-08-03"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Ismael Saibari",
+                "date_of_birth": "2001-01-28"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Munir Mohamedi",
+                "date_of_birth": "1989-05-10"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Zakaria El Ouahdi",
+                "date_of_birth": "2001-12-31"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Issa Diop",
+                "date_of_birth": "1997-01-09"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Samir El Mourabet",
+                "date_of_birth": "2005-10-06"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Gessime Yassine",
+                "date_of_birth": "2005-11-22"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Abde Ezzalzouli",
+                "date_of_birth": "2001-12-17"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Chadi Riad",
+                "date_of_birth": "2003-06-17"
+            },
+            {
+                "number": 19,
+                "pos": "DF",
+                "name": "Youssef Belammari",
+                "date_of_birth": "1998-09-20"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Ayoub El Kaabi",
+                "date_of_birth": "1993-06-25"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Ayoube Amaimouni",
+                "date_of_birth": "2004-11-30"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Ahmed Reda Tagnaouti",
+                "date_of_birth": "1996-04-05"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Bilal El Khannouss",
+                "date_of_birth": "2004-05-10"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Neil El Aynaoui",
+                "date_of_birth": "2001-07-02"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Redouane Halhal",
+                "date_of_birth": "2003-03-05"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Anass Salah-Eddine",
+                "date_of_birth": "2002-01-18"
+            }
+        ]
+    },
+    {
+        "name": "Scotland",
+        "fifa_code": "SCO",
+        "group": "C",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Angus Gunn",
+                "date_of_birth": "1996-01-22"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Aaron Hickey",
+                "date_of_birth": "2002-06-10"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Andy Robertson",
+                "date_of_birth": "1994-03-11"
+            },
+            {
+                "number": 4,
+                "pos": "MF",
+                "name": "Scott McTominay",
+                "date_of_birth": "1996-12-08"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Grant Hanley",
+                "date_of_birth": "1991-11-20"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Kieran Tierney",
+                "date_of_birth": "1997-06-05"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "John McGinn",
+                "date_of_birth": "1994-10-18"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Tyler Fletcher",
+                "date_of_birth": "2007-03-19"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Lyndon Dykes",
+                "date_of_birth": "1995-10-07"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Ché Adams",
+                "date_of_birth": "1996-07-13"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Ryan Christie",
+                "date_of_birth": "1995-02-22"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Liam Kelly",
+                "date_of_birth": "1996-01-23"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Jack Hendry",
+                "date_of_birth": "1995-05-07"
+            },
+            {
+                "number": 14,
+                "pos": "FW",
+                "name": "Ross Stewart",
+                "date_of_birth": "1996-07-11"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "John Souttar",
+                "date_of_birth": "1996-09-25"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Dominic Hyam",
+                "date_of_birth": "1995-12-20"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Ben Gannon-Doak",
+                "date_of_birth": "2005-11-11"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "George Hirst",
+                "date_of_birth": "1999-02-15"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Lewis Ferguson",
+                "date_of_birth": "1999-08-24"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Lawrence Shankland",
+                "date_of_birth": "1995-08-10"
+            },
+            {
+                "number": 21,
+                "pos": "GK",
+                "name": "Craig Gordon",
+                "date_of_birth": "1982-12-31"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Nathan Patterson",
+                "date_of_birth": "2001-10-16"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Kenny McLean",
+                "date_of_birth": "1992-01-08"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Anthony Ralston",
+                "date_of_birth": "1998-11-16"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Findlay Curtis",
+                "date_of_birth": "2006-06-09"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Scott McKenna",
+                "date_of_birth": "1996-11-12"
+            }
+        ]
+    },
+    {
+        "name": "Australia",
+        "fifa_code": "AUS",
+        "group": "D",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Mathew Ryan",
+                "date_of_birth": "1992-04-08"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Miloš Degenek",
+                "date_of_birth": "1994-04-28"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Alessandro Circati",
+                "date_of_birth": "2003-10-10"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Jacob Italiano",
+                "date_of_birth": "2001-07-30"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Jordan Bos",
+                "date_of_birth": "2002-10-29"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Jason Geria",
+                "date_of_birth": "1993-05-10"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Mathew Leckie",
+                "date_of_birth": "1991-02-04"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Connor Metcalfe",
+                "date_of_birth": "1999-11-05"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Mohamed Touré",
+                "date_of_birth": "2004-03-26"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Ajdin Hrustic",
+                "date_of_birth": "1996-07-05"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Awer Mabil",
+                "date_of_birth": "1995-09-15"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Paul Izzo",
+                "date_of_birth": "1995-01-06"
+            },
+            {
+                "number": 13,
+                "pos": "MF",
+                "name": "Aiden O'Neill",
+                "date_of_birth": "1998-07-04"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Cammy Devlin",
+                "date_of_birth": "1998-06-07"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Kai Trewin",
+                "date_of_birth": "2001-05-18"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Aziz Behich",
+                "date_of_birth": "1990-12-16"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Nestory Irankunda",
+                "date_of_birth": "2006-02-09"
+            },
+            {
+                "number": 18,
+                "pos": "GK",
+                "name": "Patrick Beach",
+                "date_of_birth": "2003-08-06"
+            },
+            {
+                "number": 19,
+                "pos": "DF",
+                "name": "Harry Souttar",
+                "date_of_birth": "1998-10-22"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Cristian Volpato",
+                "date_of_birth": "2003-11-15"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Cameron Burgess",
+                "date_of_birth": "1995-10-21"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Jackson Irvine",
+                "date_of_birth": "1993-03-07"
+            },
+            {
+                "number": 23,
+                "pos": "FW",
+                "name": "Nishan Velupillay",
+                "date_of_birth": "2001-05-07"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Paul Okon-Engstler",
+                "date_of_birth": "2005-01-24"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Lucas Herrington",
+                "date_of_birth": "2007-09-05"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Tete Yengi",
+                "date_of_birth": "2000-11-28"
+            }
+        ]
+    },
+    {
+        "name": "Paraguay",
+        "fifa_code": "PAR",
+        "group": "D",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Gatito Fernández",
+                "date_of_birth": "1988-03-29"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Gustavo Velázquez",
+                "date_of_birth": "1991-04-17"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Omar Alderete",
+                "date_of_birth": "1996-12-26"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Juan José Cáceres",
+                "date_of_birth": "2000-06-01"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Fabián Balbuena",
+                "date_of_birth": "1991-08-23"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Júnior Alonso",
+                "date_of_birth": "1993-02-09"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Ramón Sosa",
+                "date_of_birth": "1999-08-31"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Diego Gómez",
+                "date_of_birth": "2003-03-27"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Antonio Sanabria",
+                "date_of_birth": "1996-03-04"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Miguel Almirón",
+                "date_of_birth": "1994-02-10"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Maurício",
+                "date_of_birth": "2001-06-22"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Orlando Gill",
+                "date_of_birth": "2000-06-11"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "José Canale",
+                "date_of_birth": "1996-07-20"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Andrés Cubas",
+                "date_of_birth": "1996-05-11"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Gustavo Gómez",
+                "date_of_birth": "1993-05-06"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Damián Bobadilla",
+                "date_of_birth": "2001-07-11"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Kaku",
+                "date_of_birth": "1995-01-11"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Álex Arce",
+                "date_of_birth": "1995-06-16"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Julio Enciso",
+                "date_of_birth": "2004-01-23"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Braian Ojeda",
+                "date_of_birth": "2000-06-27"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Gabriel Ávalos",
+                "date_of_birth": "1990-10-12"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Gastón Olveira",
+                "date_of_birth": "1993-04-21"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Matías Galarza",
+                "date_of_birth": "2002-02-11"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Gustavo Caballero",
+                "date_of_birth": "2001-09-21"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Isidro Pitta",
+                "date_of_birth": "1999-08-14"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Alexandro Maidana",
+                "date_of_birth": "2005-07-26"
+            }
+        ]
+    },
+    {
+        "name": "Turkey",
+        "fifa_code": "TUR",
+        "group": "D",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Mert Günok",
+                "date_of_birth": "1989-03-01"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Zeki Çelik",
+                "date_of_birth": "1997-02-17"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Merih Demiral",
+                "date_of_birth": "1998-03-05"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Çağlar Söyüncü",
+                "date_of_birth": "1996-05-23"
+            },
+            {
+                "number": 5,
+                "pos": "MF",
+                "name": "Salih Özcan",
+                "date_of_birth": "1998-01-11"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Orkun Kökçü",
+                "date_of_birth": "2000-12-29"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Kerem Aktürkoğlu",
+                "date_of_birth": "1998-10-21"
+            },
+            {
+                "number": 8,
+                "pos": "FW",
+                "name": "Arda Güler",
+                "date_of_birth": "2005-02-25"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Deniz Gül",
+                "date_of_birth": "2004-07-02"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Hakan Çalhanoğlu",
+                "date_of_birth": "1994-02-08"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Kenan Yıldız",
+                "date_of_birth": "2005-05-04"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Altay Bayındır",
+                "date_of_birth": "1998-04-14"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Eren Elmalı",
+                "date_of_birth": "2000-07-07"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Abdülkerim Bardakcı",
+                "date_of_birth": "1994-09-07"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Ozan Kabak",
+                "date_of_birth": "2000-03-25"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "İsmail Yüksek",
+                "date_of_birth": "1999-01-26"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "İrfan Can Kahveci",
+                "date_of_birth": "1995-07-15"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Mert Müldür",
+                "date_of_birth": "1999-04-03"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Yunus Akgün",
+                "date_of_birth": "2000-07-07"
+            },
+            {
+                "number": 20,
+                "pos": "DF",
+                "name": "Ferdi Kadıoğlu",
+                "date_of_birth": "1999-10-07"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Barış Alper Yılmaz",
+                "date_of_birth": "2000-05-23"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Kaan Ayhan",
+                "date_of_birth": "1994-11-10"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Uğurcan Çakır",
+                "date_of_birth": "1996-04-05"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Oğuz Aydın",
+                "date_of_birth": "2000-10-27"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Samet Akaydin",
+                "date_of_birth": "1994-03-13"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Can Uzun",
+                "date_of_birth": "2005-11-11"
+            }
+        ]
+    },
+    {
+        "name": "United States",
+        "fifa_code": "USA",
+        "group": "D",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Matt Turner",
+                "date_of_birth": "1994-06-24"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Sergiño Dest",
+                "date_of_birth": "2000-11-03"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Chris Richards",
+                "date_of_birth": "2000-03-28"
+            },
+            {
+                "number": 4,
+                "pos": "MF",
+                "name": "Tyler Adams",
+                "date_of_birth": "1999-02-14"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Antonee Robinson",
+                "date_of_birth": "1997-08-08"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Auston Trusty",
+                "date_of_birth": "1998-08-12"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Giovanni Reyna",
+                "date_of_birth": "2002-11-13"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Weston McKennie",
+                "date_of_birth": "1998-08-28"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Ricardo Pepi",
+                "date_of_birth": "2003-01-09"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Christian Pulisic",
+                "date_of_birth": "1998-09-18"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Brenden Aaronson",
+                "date_of_birth": "2000-10-22"
+            },
+            {
+                "number": 12,
+                "pos": "DF",
+                "name": "Miles Robinson",
+                "date_of_birth": "1997-03-14"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Tim Ream",
+                "date_of_birth": "1987-10-05"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Sebastian Berhalter",
+                "date_of_birth": "2001-05-10"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Cristian Roldan",
+                "date_of_birth": "1995-06-03"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Alex Freeman",
+                "date_of_birth": "2004-08-09"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Malik Tillman",
+                "date_of_birth": "2002-05-28"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Max Arfsten",
+                "date_of_birth": "2001-04-19"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Haji Wright",
+                "date_of_birth": "1998-03-27"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Folarin Balogun",
+                "date_of_birth": "2001-07-03"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Timothy Weah",
+                "date_of_birth": "2000-02-22"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Mark McKenzie",
+                "date_of_birth": "1999-02-25"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Joe Scally",
+                "date_of_birth": "2002-12-31"
+            },
+            {
+                "number": 24,
+                "pos": "GK",
+                "name": "Matt Freese",
+                "date_of_birth": "1998-09-02"
+            },
+            {
+                "number": 25,
+                "pos": "GK",
+                "name": "Chris Brady",
+                "date_of_birth": "2004-03-03"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Alejandro Zendejas",
+                "date_of_birth": "1998-02-07"
+            }
+        ]
+    },
+    {
+        "name": "Curaçao",
+        "fifa_code": "CUW",
+        "group": "E",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Eloy Room",
+                "date_of_birth": "1989-02-06"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Shurandy Sambo",
+                "date_of_birth": "2001-08-19"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Juriën Gaari",
+                "date_of_birth": "1993-12-23"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Roshon van Eijma",
+                "date_of_birth": "1998-06-09"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Sherel Floranus",
+                "date_of_birth": "1998-08-23"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Godfried Roemeratoe",
+                "date_of_birth": "1999-08-19"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Juninho Bacuna",
+                "date_of_birth": "1997-08-07"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Livano Comenencia",
+                "date_of_birth": "2004-02-03"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Jürgen Locadia",
+                "date_of_birth": "1993-11-07"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Leandro Bacuna",
+                "date_of_birth": "1991-08-21"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Jeremy Antonisse",
+                "date_of_birth": "2002-03-29"
+            },
+            {
+                "number": 12,
+                "pos": "FW",
+                "name": "Sontje Hansen",
+                "date_of_birth": "2002-05-18"
+            },
+            {
+                "number": 13,
+                "pos": "FW",
+                "name": "Tyrese Noslin",
+                "date_of_birth": "2002-09-11"
+            },
+            {
+                "number": 14,
+                "pos": "FW",
+                "name": "Kenji Gorré",
+                "date_of_birth": "1994-09-29"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Ar'jany Martha",
+                "date_of_birth": "2003-09-04"
+            },
+            {
+                "number": 16,
+                "pos": "FW",
+                "name": "Jearl Margaritha",
+                "date_of_birth": "2000-04-10"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Brandley Kuwas",
+                "date_of_birth": "1992-09-19"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Armando Obispo",
+                "date_of_birth": "1999-03-05"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Gervane Kastaneer",
+                "date_of_birth": "1996-06-09"
+            },
+            {
+                "number": 20,
+                "pos": "DF",
+                "name": "Joshua Brenet",
+                "date_of_birth": "1994-03-20"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Tahith Chong",
+                "date_of_birth": "1999-12-04"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Kevin Felida",
+                "date_of_birth": "1999-11-11"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Riechedly Bazoer",
+                "date_of_birth": "1996-10-12"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Deveron Fonville",
+                "date_of_birth": "2003-05-16"
+            },
+            {
+                "number": 25,
+                "pos": "GK",
+                "name": "Tyrick Bodak",
+                "date_of_birth": "2002-05-15"
+            },
+            {
+                "number": 26,
+                "pos": "GK",
+                "name": "Trevor Doornbusch",
+                "date_of_birth": "1999-07-06"
+            }
+        ]
+    },
+    {
+        "name": "Ecuador",
+        "fifa_code": "ECU",
+        "group": "E",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Hernán Galíndez",
+                "date_of_birth": "1987-03-30"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Félix Torres",
+                "date_of_birth": "1997-01-11"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Piero Hincapié",
+                "date_of_birth": "2002-01-09"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Joel Ordóñez",
+                "date_of_birth": "2004-04-21"
+            },
+            {
+                "number": 5,
+                "pos": "MF",
+                "name": "Jordy Alcívar",
+                "date_of_birth": "1999-08-05"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Willian Pacho",
+                "date_of_birth": "2001-10-16"
+            },
+            {
+                "number": 7,
+                "pos": "DF",
+                "name": "Pervis Estupiñán",
+                "date_of_birth": "1998-01-21"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Anthony Valencia",
+                "date_of_birth": "2003-07-21"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "John Yeboah",
+                "date_of_birth": "2000-06-23"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Kendry Páez",
+                "date_of_birth": "2007-05-04"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Kevin Rodríguez",
+                "date_of_birth": "2000-03-04"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Moisés Ramírez",
+                "date_of_birth": "2000-09-09"
+            },
+            {
+                "number": 13,
+                "pos": "FW",
+                "name": "Enner Valencia",
+                "date_of_birth": "1989-11-04"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Alan Minda",
+                "date_of_birth": "2003-05-14"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Pedro Vite",
+                "date_of_birth": "2002-03-09"
+            },
+            {
+                "number": 16,
+                "pos": "FW",
+                "name": "Jordy Caicedo",
+                "date_of_birth": "1997-11-18"
+            },
+            {
+                "number": 17,
+                "pos": "DF",
+                "name": "Ángelo Preciado",
+                "date_of_birth": "1998-02-18"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Denil Castillo",
+                "date_of_birth": "2004-03-24"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Gonzalo Plata",
+                "date_of_birth": "2000-11-01"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Nilson Angulo",
+                "date_of_birth": "2003-06-19"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Alan Franco",
+                "date_of_birth": "1998-08-21"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Gonzalo Valle",
+                "date_of_birth": "1996-02-28"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Moisés Caicedo",
+                "date_of_birth": "2001-11-02"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Jeremy Arévalo",
+                "date_of_birth": "2005-03-19"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Jackson Porozo",
+                "date_of_birth": "2000-08-04"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Yaimar Medina",
+                "date_of_birth": "2004-11-05"
+            }
+        ]
+    },
+    {
+        "name": "Germany",
+        "fifa_code": "GER",
+        "group": "E",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Manuel Neuer",
+                "date_of_birth": "1986-03-27"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Antonio Rüdiger",
+                "date_of_birth": "1993-03-03"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Waldemar Anton",
+                "date_of_birth": "1996-07-20"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Jonathan Tah",
+                "date_of_birth": "1996-02-11"
+            },
+            {
+                "number": 5,
+                "pos": "MF",
+                "name": "Aleksandar Pavlović",
+                "date_of_birth": "2004-05-03"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Joshua Kimmich",
+                "date_of_birth": "1995-02-08"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Kai Havertz",
+                "date_of_birth": "1999-06-11"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Leon Goretzka",
+                "date_of_birth": "1995-02-06"
+            },
+            {
+                "number": 9,
+                "pos": "MF",
+                "name": "Jamie Leweling",
+                "date_of_birth": "2001-02-26"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Jamal Musiala",
+                "date_of_birth": "2003-02-26"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Nick Woltemade",
+                "date_of_birth": "2002-02-14"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Oliver Baumann",
+                "date_of_birth": "1990-06-02"
+            },
+            {
+                "number": 13,
+                "pos": "MF",
+                "name": "Pascal Groß",
+                "date_of_birth": "1991-06-15"
+            },
+            {
+                "number": 14,
+                "pos": "FW",
+                "name": "Maximilian Beier",
+                "date_of_birth": "2002-10-17"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Nico Schlotterbeck",
+                "date_of_birth": "1999-12-01"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Angelo Stiller",
+                "date_of_birth": "2001-04-04"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Florian Wirtz",
+                "date_of_birth": "2003-05-03"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Nathaniel Brown",
+                "date_of_birth": "2003-06-16"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Leroy Sané",
+                "date_of_birth": "1996-01-11"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Nadiem Amiri",
+                "date_of_birth": "1996-10-27"
+            },
+            {
+                "number": 21,
+                "pos": "GK",
+                "name": "Alexander Nübel",
+                "date_of_birth": "1996-09-30"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "David Raum",
+                "date_of_birth": "1998-04-22"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Felix Nmecha",
+                "date_of_birth": "2000-10-10"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Malick Thiaw",
+                "date_of_birth": "2001-08-08"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Assan Ouédraogo",
+                "date_of_birth": "2006-05-09"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Deniz Undav",
+                "date_of_birth": "1996-07-19"
+            }
+        ]
+    },
+    {
+        "name": "Ivory Coast",
+        "fifa_code": "CIV",
+        "group": "E",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Yahia Fofana",
+                "date_of_birth": "2000-08-21"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Ousmane Diomande",
+                "date_of_birth": "2003-12-04"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Ghislain Konan",
+                "date_of_birth": "1995-12-27"
+            },
+            {
+                "number": 4,
+                "pos": "MF",
+                "name": "Jean Michaël Seri",
+                "date_of_birth": "1991-07-19"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Wilfried Singo",
+                "date_of_birth": "2000-12-25"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Seko Fofana",
+                "date_of_birth": "1995-05-07"
+            },
+            {
+                "number": 7,
+                "pos": "DF",
+                "name": "Odilon Kossounou",
+                "date_of_birth": "2001-01-04"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Franck Kessié",
+                "date_of_birth": "1996-12-19"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Ange-Yoan Bonny",
+                "date_of_birth": "2003-10-25"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Simon Adingra",
+                "date_of_birth": "2002-01-01"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Yan Diomande",
+                "date_of_birth": "2006-11-14"
+            },
+            {
+                "number": 12,
+                "pos": "FW",
+                "name": "Elye Wahi",
+                "date_of_birth": "2003-01-02"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Christopher Opéri",
+                "date_of_birth": "1997-04-29"
+            },
+            {
+                "number": 14,
+                "pos": "FW",
+                "name": "Oumar Diakité",
+                "date_of_birth": "2003-12-20"
+            },
+            {
+                "number": 15,
+                "pos": "FW",
+                "name": "Amad Diallo",
+                "date_of_birth": "2002-07-11"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Mohamed Koné",
+                "date_of_birth": "2002-03-07"
+            },
+            {
+                "number": 17,
+                "pos": "DF",
+                "name": "Guéla Doué",
+                "date_of_birth": "2002-10-17"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Ibrahim Sangaré",
+                "date_of_birth": "1997-12-02"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Nicolas Pépé",
+                "date_of_birth": "1995-05-29"
+            },
+            {
+                "number": 20,
+                "pos": "DF",
+                "name": "Emmanuel Agbadou",
+                "date_of_birth": "1997-06-17"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Evan Ndicka",
+                "date_of_birth": "1999-08-20"
+            },
+            {
+                "number": 22,
+                "pos": "FW",
+                "name": "Evann Guessand",
+                "date_of_birth": "2001-07-01"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Alban Lafont",
+                "date_of_birth": "1999-01-23"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Bazoumana Touré",
+                "date_of_birth": "2006-03-02"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Parfait Guiagon",
+                "date_of_birth": "2001-02-22"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Christ Inao Oulaï",
+                "date_of_birth": "2006-04-06"
+            }
+        ]
+    },
+    {
+        "name": "Japan",
+        "fifa_code": "JPN",
+        "group": "F",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Zion Suzuki",
+                "date_of_birth": "2002-08-21"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Yukinari Sugawara",
+                "date_of_birth": "2000-06-28"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Shōgo Taniguchi",
+                "date_of_birth": "1991-07-15"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Kō Itakura",
+                "date_of_birth": "1997-01-27"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Yūto Nagatomo",
+                "date_of_birth": "1986-09-12"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Wataru Endo",
+                "date_of_birth": "1993-02-09"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Ao Tanaka",
+                "date_of_birth": "1998-09-10"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Takefusa Kubo",
+                "date_of_birth": "2001-06-04"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Keisuke Gotō",
+                "date_of_birth": "2005-06-03"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Ritsu Dōan",
+                "date_of_birth": "1998-06-16"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Daizen Maeda",
+                "date_of_birth": "1997-10-20"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Keisuke Ōsako",
+                "date_of_birth": "1999-07-28"
+            },
+            {
+                "number": 13,
+                "pos": "MF",
+                "name": "Keito Nakamura",
+                "date_of_birth": "2000-07-28"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Junya Itō",
+                "date_of_birth": "1993-03-09"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Daichi Kamada",
+                "date_of_birth": "1996-08-05"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Tsuyoshi Watanabe",
+                "date_of_birth": "1997-02-05"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Yuito Suzuki",
+                "date_of_birth": "2001-10-25"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Ayase Ueda",
+                "date_of_birth": "1998-08-28"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Kōki Ogawa",
+                "date_of_birth": "1997-08-08"
+            },
+            {
+                "number": 20,
+                "pos": "DF",
+                "name": "Ayumu Seko",
+                "date_of_birth": "2000-06-07"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Hiroki Itō",
+                "date_of_birth": "1999-05-12"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Takehiro Tomiyasu",
+                "date_of_birth": "1998-11-05"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Tomoki Hayakawa",
+                "date_of_birth": "1999-03-03"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Kaishū Sano",
+                "date_of_birth": "2000-12-30"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Junnosuke Suzuki",
+                "date_of_birth": "2003-07-12"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Kento Shiogai",
+                "date_of_birth": "2005-03-26"
+            }
+        ]
+    },
+    {
+        "name": "Netherlands",
+        "fifa_code": "NED",
+        "group": "F",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Bart Verbruggen",
+                "date_of_birth": "2002-08-18"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Lutsharel Geertruida",
+                "date_of_birth": "2000-07-18"
+            },
+            {
+                "number": 3,
+                "pos": "MF",
+                "name": "Marten de Roon",
+                "date_of_birth": "1991-03-29"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Virgil van Dijk",
+                "date_of_birth": "1991-07-08"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Nathan Aké",
+                "date_of_birth": "1995-02-18"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Jan Paul van Hecke",
+                "date_of_birth": "2000-06-08"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Justin Kluivert",
+                "date_of_birth": "1999-05-05"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Ryan Gravenberch",
+                "date_of_birth": "2002-05-16"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Wout Weghorst",
+                "date_of_birth": "1992-08-07"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Memphis Depay",
+                "date_of_birth": "1994-02-13"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Cody Gakpo",
+                "date_of_birth": "1999-05-07"
+            },
+            {
+                "number": 12,
+                "pos": "DF",
+                "name": "Mats Wieffer",
+                "date_of_birth": "1999-11-16"
+            },
+            {
+                "number": 13,
+                "pos": "GK",
+                "name": "Robin Roefs",
+                "date_of_birth": "2003-01-17"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Tijjani Reijnders",
+                "date_of_birth": "1998-07-29"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Micky van de Ven",
+                "date_of_birth": "2001-04-19"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Guus Til",
+                "date_of_birth": "1997-12-22"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Noa Lang",
+                "date_of_birth": "1999-06-17"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Donyell Malen",
+                "date_of_birth": "1999-01-19"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Brian Brobbey",
+                "date_of_birth": "2002-02-01"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Teun Koopmeiners",
+                "date_of_birth": "1998-02-28"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Frenkie de Jong",
+                "date_of_birth": "1997-05-12"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Denzel Dumfries",
+                "date_of_birth": "1996-04-18"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Mark Flekken",
+                "date_of_birth": "1993-06-13"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Crysencio Summerville",
+                "date_of_birth": "2001-10-30"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Jorrel Hato",
+                "date_of_birth": "2006-03-07"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Quinten Timber",
+                "date_of_birth": "2001-06-17"
+            }
+        ]
+    },
+    {
+        "name": "Sweden",
+        "fifa_code": "SWE",
+        "group": "F",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Jacob Widell Zetterström",
+                "date_of_birth": "1998-07-11"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Gustaf Lagerbielke",
+                "date_of_birth": "2000-04-10"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Victor Lindelöf",
+                "date_of_birth": "1994-07-17"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Isak Hien",
+                "date_of_birth": "1999-01-13"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Gabriel Gudmundsson",
+                "date_of_birth": "1999-04-29"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Herman Johansson",
+                "date_of_birth": "1997-10-16"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Lucas Bergvall",
+                "date_of_birth": "2006-02-02"
+            },
+            {
+                "number": 8,
+                "pos": "DF",
+                "name": "Daniel Svensson",
+                "date_of_birth": "2002-02-12"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Alexander Isak",
+                "date_of_birth": "1999-09-21"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Benjamin Nygren",
+                "date_of_birth": "2001-07-08"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Anthony Elanga",
+                "date_of_birth": "2002-04-27"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Viktor Johansson",
+                "date_of_birth": "1998-09-14"
+            },
+            {
+                "number": 13,
+                "pos": "MF",
+                "name": "Ken Sema",
+                "date_of_birth": "1993-09-30"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Hjalmar Ekdal",
+                "date_of_birth": "1998-10-21"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Carl Starfelt",
+                "date_of_birth": "1995-06-01"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Jesper Karlström",
+                "date_of_birth": "1995-06-21"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Viktor Gyökeres",
+                "date_of_birth": "1998-06-04"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Yasin Ayari",
+                "date_of_birth": "2003-10-06"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Mattias Svanberg",
+                "date_of_birth": "1999-01-05"
+            },
+            {
+                "number": 20,
+                "pos": "DF",
+                "name": "Eric Smith",
+                "date_of_birth": "1997-01-08"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Alexander Bernhardsson",
+                "date_of_birth": "1998-09-08"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Besfort Zeneli",
+                "date_of_birth": "2002-11-21"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Kristoffer Nordfeldt",
+                "date_of_birth": "1989-06-23"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Elliot Stroud",
+                "date_of_birth": "2002-06-22"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Gustaf Nilsson",
+                "date_of_birth": "1997-05-23"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Taha Ali",
+                "date_of_birth": "1998-07-01"
+            }
+        ]
+    },
+    {
+        "name": "Tunisia",
+        "fifa_code": "TUN",
+        "group": "F",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Mouhib Chamakh",
+                "date_of_birth": "2001-08-25"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Ali Abdi",
+                "date_of_birth": "1993-12-20"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Montassar Talbi",
+                "date_of_birth": "1998-05-26"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Omar Rekik",
+                "date_of_birth": "2001-12-20"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Adem Arous",
+                "date_of_birth": "2004-07-17"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Dylan Bronn",
+                "date_of_birth": "1995-06-19"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Elias Achouri",
+                "date_of_birth": "1999-02-10"
+            },
+            {
+                "number": 8,
+                "pos": "FW",
+                "name": "Elias Saad",
+                "date_of_birth": "1999-12-27"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Hazem Mastouri",
+                "date_of_birth": "1997-06-18"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Hannibal Mejbri",
+                "date_of_birth": "2003-01-21"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Ismaël Gharbi",
+                "date_of_birth": "2004-04-10"
+            },
+            {
+                "number": 12,
+                "pos": "DF",
+                "name": "Mortadha Ben Ouanes",
+                "date_of_birth": "1994-07-02"
+            },
+            {
+                "number": 13,
+                "pos": "MF",
+                "name": "Rani Khedira",
+                "date_of_birth": "1994-01-27"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Khalil Ayari",
+                "date_of_birth": "2005-02-02"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Hadj Mahmoud",
+                "date_of_birth": "2000-04-24"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Aymen Dahmen",
+                "date_of_birth": "1997-01-28"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Ellyes Skhiri",
+                "date_of_birth": "1995-05-10"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Rayan Elloumi",
+                "date_of_birth": "2007-09-17"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Firas Chaouat",
+                "date_of_birth": "1996-05-08"
+            },
+            {
+                "number": 20,
+                "pos": "DF",
+                "name": "Yan Valery",
+                "date_of_birth": "1999-02-22"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Mohamed Amine Ben Hamida",
+                "date_of_birth": "1995-12-15"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Sabri Ben Hessen",
+                "date_of_birth": "1996-06-13"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Moutaz Neffati",
+                "date_of_birth": "2004-09-04"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Raed Chikhaoui",
+                "date_of_birth": "2004-06-09"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Anis Ben Slimane",
+                "date_of_birth": "2001-03-16"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Sebastian Tounekti",
+                "date_of_birth": "2002-07-13"
+            }
+        ]
+    },
+    {
+        "name": "Belgium",
+        "fifa_code": "BEL",
+        "group": "G",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Thibaut Courtois",
+                "date_of_birth": "1992-05-11"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Zeno Debast",
+                "date_of_birth": "2003-10-24"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Arthur Theate",
+                "date_of_birth": "2000-05-25"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Brandon Mechele",
+                "date_of_birth": "1993-01-28"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Maxim De Cuyper",
+                "date_of_birth": "2000-12-22"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Axel Witsel",
+                "date_of_birth": "1989-01-12"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Kevin De Bruyne",
+                "date_of_birth": "1991-06-28"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Youri Tielemans",
+                "date_of_birth": "1997-05-07"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Romelu Lukaku",
+                "date_of_birth": "1993-05-13"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Leandro Trossard",
+                "date_of_birth": "1994-12-04"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Jérémy Doku",
+                "date_of_birth": "2002-05-27"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Senne Lammens",
+                "date_of_birth": "2002-07-07"
+            },
+            {
+                "number": 13,
+                "pos": "GK",
+                "name": "Mike Penders",
+                "date_of_birth": "2005-07-31"
+            },
+            {
+                "number": 14,
+                "pos": "FW",
+                "name": "Dodi Lukébakio",
+                "date_of_birth": "1997-09-24"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Thomas Meunier",
+                "date_of_birth": "1991-09-12"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Koni De Winter",
+                "date_of_birth": "2002-06-12"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Charles De Ketelaere",
+                "date_of_birth": "2001-03-10"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Joaquin Seys",
+                "date_of_birth": "2005-03-28"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Diego Moreira",
+                "date_of_birth": "2004-08-06"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Hans Vanaken",
+                "date_of_birth": "1992-08-24"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Timothy Castagne",
+                "date_of_birth": "1995-12-05"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Alexis Saelemaekers",
+                "date_of_birth": "1999-06-27"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Nicolas Raskin",
+                "date_of_birth": "2001-02-23"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Amadou Onana",
+                "date_of_birth": "2001-08-16"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Nathan Ngoy",
+                "date_of_birth": "2003-06-10"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Matias Fernandez-Pardo",
+                "date_of_birth": "2005-02-03"
+            }
+        ]
+    },
+    {
+        "name": "Egypt",
+        "fifa_code": "EGY",
+        "group": "G",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Mohamed El Shenawy",
+                "date_of_birth": "1988-12-18"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Yasser Ibrahim",
+                "date_of_birth": "1993-02-10"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Mohamed Hany",
+                "date_of_birth": "1996-02-02"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Hossam Abdelmaguid",
+                "date_of_birth": "2001-04-30"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Ramy Rabia",
+                "date_of_birth": "1993-05-20"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Mohamed Abdelmonem",
+                "date_of_birth": "1999-02-01"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Trézéguet",
+                "date_of_birth": "1994-10-01"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Emam Ashour",
+                "date_of_birth": "1998-02-20"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Hamza Abdelkarim",
+                "date_of_birth": "2008-01-01"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Mohamed Salah",
+                "date_of_birth": "1992-06-15"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Mostafa Ziko",
+                "date_of_birth": "1997-04-27"
+            },
+            {
+                "number": 12,
+                "pos": "FW",
+                "name": "Haissem Hassan",
+                "date_of_birth": "2002-02-08"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Ahmed Fatouh",
+                "date_of_birth": "1998-03-22"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Hamdy Fathy",
+                "date_of_birth": "1994-09-29"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Karim Hafez",
+                "date_of_birth": "1996-03-12"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "El Mahdy Soliman",
+                "date_of_birth": "1987-06-08"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Mohanad Lasheen",
+                "date_of_birth": "1996-05-29"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Nabil Emad",
+                "date_of_birth": "1996-04-06"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Marwan Attia",
+                "date_of_birth": "1998-08-01"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Ibrahim Adel",
+                "date_of_birth": "2001-04-23"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Mahmoud Saber",
+                "date_of_birth": "2001-07-30"
+            },
+            {
+                "number": 22,
+                "pos": "FW",
+                "name": "Omar Marmoush",
+                "date_of_birth": "1999-02-07"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Mostafa Shobeir",
+                "date_of_birth": "2000-05-15"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Tarek Alaa",
+                "date_of_birth": "2002-01-05"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Zizo",
+                "date_of_birth": "1996-01-10"
+            },
+            {
+                "number": 26,
+                "pos": "GK",
+                "name": "Mohamed Alaa",
+                "date_of_birth": "1999-01-01"
+            }
+        ]
+    },
+    {
+        "name": "Iran",
+        "fifa_code": "IRN",
+        "group": "G",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Alireza Beiranvand",
+                "date_of_birth": "1992-09-21"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Saleh Hardani",
+                "date_of_birth": "1998-12-26"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Ehsan Hajsafi",
+                "date_of_birth": "1990-02-25"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Shojae Khalilzadeh",
+                "date_of_birth": "1989-05-14"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Milad Mohammadi",
+                "date_of_birth": "1993-09-29"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Saeid Ezatolahi",
+                "date_of_birth": "1996-10-01"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Alireza Jahanbakhsh",
+                "date_of_birth": "1993-08-11"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Mohammad Mohebi",
+                "date_of_birth": "1998-12-20"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Mehdi Taremi",
+                "date_of_birth": "1992-07-18"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Mehdi Ghayedi",
+                "date_of_birth": "1998-12-05"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Ali Alipour",
+                "date_of_birth": "1995-11-11"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Payam Niazmand",
+                "date_of_birth": "1995-04-06"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Hossein Kanaanizadegan",
+                "date_of_birth": "1994-03-23"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Saman Ghoddos",
+                "date_of_birth": "1993-09-06"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Rouzbeh Cheshmi",
+                "date_of_birth": "1993-07-24"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Mehdi Torabi",
+                "date_of_birth": "1994-09-10"
+            },
+            {
+                "number": 17,
+                "pos": "DF",
+                "name": "Aria Yousefi",
+                "date_of_birth": "2002-04-22"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Amirhossein Hosseinzadeh",
+                "date_of_birth": "2000-10-30"
+            },
+            {
+                "number": 19,
+                "pos": "DF",
+                "name": "Ali Nemati",
+                "date_of_birth": "1996-02-08"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Shahriyar Moghanlou",
+                "date_of_birth": "1994-12-21"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Mohammad Ghorbani",
+                "date_of_birth": "2001-10-07"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Hossein Hosseini",
+                "date_of_birth": "1992-06-30"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Ramin Rezaeian",
+                "date_of_birth": "1990-03-21"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Dennis Eckert",
+                "date_of_birth": "1997-01-09"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Danial Eiri",
+                "date_of_birth": "2003-10-26"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Amirmohammad Razzaghinia",
+                "date_of_birth": "2006-04-11"
+            }
+        ]
+    },
+    {
+        "name": "New Zealand",
+        "fifa_code": "NZL",
+        "group": "G",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Max Crocombe",
+                "date_of_birth": "1993-08-12"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Tim Payne",
+                "date_of_birth": "1994-01-10"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Francis de Vries",
+                "date_of_birth": "1994-11-28"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Tyler Bindon",
+                "date_of_birth": "2005-01-27"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Michael Boxall",
+                "date_of_birth": "1988-08-18"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Joe Bell",
+                "date_of_birth": "1999-04-27"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Matthew Garbett",
+                "date_of_birth": "2002-04-13"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Marko Stamenić",
+                "date_of_birth": "2002-02-19"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Chris Wood",
+                "date_of_birth": "1991-12-07"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Sarpreet Singh",
+                "date_of_birth": "1999-02-20"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Elijah Just",
+                "date_of_birth": "2000-05-01"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Alex Paulsen",
+                "date_of_birth": "2002-07-04"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Liberato Cacace",
+                "date_of_birth": "2000-09-27"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Alex Rufer",
+                "date_of_birth": "1996-06-12"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Nando Pijnaker",
+                "date_of_birth": "1999-02-25"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Finn Surman",
+                "date_of_birth": "2003-09-23"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Kosta Barbarouses",
+                "date_of_birth": "1990-02-19"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Ben Waine",
+                "date_of_birth": "2001-06-11"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Ben Old",
+                "date_of_birth": "2002-08-13"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Callum McCowatt",
+                "date_of_birth": "1999-04-30"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Jesse Randall",
+                "date_of_birth": "2002-08-19"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Michael Woud",
+                "date_of_birth": "1999-01-16"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Ryan Thomas",
+                "date_of_birth": "1994-12-20"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Callan Elliot",
+                "date_of_birth": "1999-07-07"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Lachlan Bayliss",
+                "date_of_birth": "2002-07-24"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Tommy Smith",
+                "date_of_birth": "1990-03-31"
+            }
+        ]
+    },
+    {
+        "name": "Cape Verde",
+        "fifa_code": "CPV",
+        "group": "H",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Vozinha",
+                "date_of_birth": "1986-06-03"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Stopira",
+                "date_of_birth": "1988-05-20"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Diney",
+                "date_of_birth": "1995-01-17"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Roberto Lopes",
+                "date_of_birth": "1992-06-17"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Logan Costa",
+                "date_of_birth": "2001-04-01"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Kevin Pina",
+                "date_of_birth": "1997-01-27"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Jovane Cabral",
+                "date_of_birth": "1998-06-14"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "João Paulo",
+                "date_of_birth": "1998-05-26"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Gilson Benchimol",
+                "date_of_birth": "2001-12-29"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Jamiro Monteiro",
+                "date_of_birth": "1993-11-23"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Garry Rodrigues",
+                "date_of_birth": "1990-11-27"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Márcio Rosa",
+                "date_of_birth": "1997-02-23"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Sidny Lopes Cabral",
+                "date_of_birth": "2002-09-18"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Deroy Duarte",
+                "date_of_birth": "1999-07-04"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Laros Duarte",
+                "date_of_birth": "1997-02-28"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Yannick Semedo",
+                "date_of_birth": "1995-12-29"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Willy Semedo",
+                "date_of_birth": "1994-04-27"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Telmo Arcanjo",
+                "date_of_birth": "2001-06-21"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Dailon Livramento",
+                "date_of_birth": "2001-05-04"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Ryan Mendes",
+                "date_of_birth": "1990-01-08"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Nuno da Costa",
+                "date_of_birth": "1991-02-10"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Steven Moreira",
+                "date_of_birth": "1994-08-13"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "CJ dos Santos",
+                "date_of_birth": "2000-08-24"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Wagner Pina",
+                "date_of_birth": "2002-11-03"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Kelvin Pires",
+                "date_of_birth": "2000-06-05"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Hélio Varela",
+                "date_of_birth": "2002-05-03"
+            }
+        ]
+    },
+    {
+        "name": "Saudi Arabia",
+        "fifa_code": "KSA",
+        "group": "H",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Nawaf Al-Aqidi",
+                "date_of_birth": "2000-05-10"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Ali Majrashi",
+                "date_of_birth": "1999-10-02"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Ali Lajami",
+                "date_of_birth": "1996-04-24"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Abdulelah Al-Amri",
+                "date_of_birth": "1997-01-15"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Hassan Al-Tambakti",
+                "date_of_birth": "1999-02-09"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Nasser Al-Dawsari",
+                "date_of_birth": "1998-12-19"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Musab Al-Juwayr",
+                "date_of_birth": "2003-06-20"
+            },
+            {
+                "number": 8,
+                "pos": "FW",
+                "name": "Ayman Yahya",
+                "date_of_birth": "2001-05-14"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Firas Al-Buraikan",
+                "date_of_birth": "2000-05-14"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Salem Al-Dawsari",
+                "date_of_birth": "1991-08-19"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Saleh Al-Shehri",
+                "date_of_birth": "1993-11-01"
+            },
+            {
+                "number": 12,
+                "pos": "DF",
+                "name": "Saud Abdulhamid",
+                "date_of_birth": "1999-07-18"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Nawaf Boushal",
+                "date_of_birth": "1999-09-16"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Hassan Kadesh",
+                "date_of_birth": "1992-09-26"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Abdullah Al-Khaibari",
+                "date_of_birth": "1996-08-16"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Ziyad Al-Johani",
+                "date_of_birth": "2001-11-11"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Khalid Al-Ghannam",
+                "date_of_birth": "2000-11-08"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Alaa Al-Hejji",
+                "date_of_birth": "1995-12-03"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Abdullah Al-Hamdan",
+                "date_of_birth": "1999-09-13"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Sultan Mandash",
+                "date_of_birth": "1994-10-17"
+            },
+            {
+                "number": 21,
+                "pos": "GK",
+                "name": "Mohammed Al-Owais",
+                "date_of_birth": "1991-10-10"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Ahmed Al-Kassar",
+                "date_of_birth": "1991-05-08"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Mohamed Kanno",
+                "date_of_birth": "1994-09-22"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Moteb Al-Harbi",
+                "date_of_birth": "2000-02-20"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Jehad Thakri",
+                "date_of_birth": "2001-07-21"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Mohammed Abu Al-Shamat",
+                "date_of_birth": "2002-08-11"
+            }
+        ]
+    },
+    {
+        "name": "Spain",
+        "fifa_code": "ESP",
+        "group": "H",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "David Raya",
+                "date_of_birth": "1995-09-15"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Marc Pubill",
+                "date_of_birth": "2003-06-20"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Álex Grimaldo",
+                "date_of_birth": "1995-09-20"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Eric García",
+                "date_of_birth": "2001-01-09"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Marcos Llorente",
+                "date_of_birth": "1995-01-30"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Mikel Merino",
+                "date_of_birth": "1996-06-22"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Ferran Torres",
+                "date_of_birth": "2000-02-29"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Fabián Ruiz",
+                "date_of_birth": "1996-04-03"
+            },
+            {
+                "number": 9,
+                "pos": "MF",
+                "name": "Gavi",
+                "date_of_birth": "2004-08-05"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Dani Olmo",
+                "date_of_birth": "1998-05-07"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Yéremy Pino",
+                "date_of_birth": "2002-10-20"
+            },
+            {
+                "number": 12,
+                "pos": "DF",
+                "name": "Pedro Porro",
+                "date_of_birth": "1999-09-13"
+            },
+            {
+                "number": 13,
+                "pos": "GK",
+                "name": "Joan Garcia",
+                "date_of_birth": "2001-05-04"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Aymeric Laporte",
+                "date_of_birth": "1994-05-27"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Álex Baena",
+                "date_of_birth": "2001-07-20"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Rodri",
+                "date_of_birth": "1996-06-22"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Nico Williams",
+                "date_of_birth": "2002-07-12"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Martín Zubimendi",
+                "date_of_birth": "1999-02-02"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Lamine Yamal",
+                "date_of_birth": "2007-07-13"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Pedri",
+                "date_of_birth": "2002-11-25"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Mikel Oyarzabal",
+                "date_of_birth": "1997-04-21"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Pau Cubarsí",
+                "date_of_birth": "2007-01-22"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Unai Simón",
+                "date_of_birth": "1997-06-11"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Marc Cucurella",
+                "date_of_birth": "1998-07-22"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Víctor Muñoz",
+                "date_of_birth": "2003-07-13"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Borja Iglesias",
+                "date_of_birth": "1993-01-17"
+            }
+        ]
+    },
+    {
+        "name": "Uruguay",
+        "fifa_code": "URU",
+        "group": "H",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Sergio Rochet",
+                "date_of_birth": "1993-03-23"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "José Giménez",
+                "date_of_birth": "1995-01-20"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Sebastián Cáceres",
+                "date_of_birth": "1999-08-18"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Ronald Araújo",
+                "date_of_birth": "1999-03-07"
+            },
+            {
+                "number": 5,
+                "pos": "MF",
+                "name": "Manuel Ugarte",
+                "date_of_birth": "2001-04-11"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Rodrigo Bentancur",
+                "date_of_birth": "1997-06-25"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Nicolás de la Cruz",
+                "date_of_birth": "1997-06-01"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Federico Valverde",
+                "date_of_birth": "1998-07-22"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Darwin Núñez",
+                "date_of_birth": "1999-06-24"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Giorgian de Arrascaeta",
+                "date_of_birth": "1994-06-01"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Facundo Pellistri",
+                "date_of_birth": "2001-12-20"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Santiago Mele",
+                "date_of_birth": "1997-09-06"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Guillermo Varela",
+                "date_of_birth": "1993-03-24"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Agustín Canobbio",
+                "date_of_birth": "1998-10-01"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Emiliano Martínez",
+                "date_of_birth": "1999-08-17"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Mathías Olivera",
+                "date_of_birth": "1997-10-31"
+            },
+            {
+                "number": 17,
+                "pos": "DF",
+                "name": "Matías Viña",
+                "date_of_birth": "1997-11-09"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Brian Rodríguez",
+                "date_of_birth": "2000-05-20"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Rodrigo Aguirre",
+                "date_of_birth": "1994-10-01"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Maximiliano Araújo",
+                "date_of_birth": "2000-02-15"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Federico Viñas",
+                "date_of_birth": "1998-06-30"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Joaquín Piquerez",
+                "date_of_birth": "1998-08-24"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Fernando Muslera",
+                "date_of_birth": "1986-06-16"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Santiago Bueno",
+                "date_of_birth": "1998-11-09"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Juan Manuel Sanabria",
+                "date_of_birth": "2000-03-29"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Rodrigo Zalazar",
+                "date_of_birth": "1999-08-12"
+            }
+        ]
+    },
+    {
+        "name": "France",
+        "fifa_code": "FRA",
+        "group": "I",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Brice Samba",
+                "date_of_birth": "1994-04-25"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Malo Gusto",
+                "date_of_birth": "2003-05-19"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Lucas Digne",
+                "date_of_birth": "1993-07-20"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Dayot Upamecano",
+                "date_of_birth": "1998-10-27"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Jules Koundé",
+                "date_of_birth": "1998-11-12"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Manu Koné",
+                "date_of_birth": "2001-05-17"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Ousmane Dembélé",
+                "date_of_birth": "1997-05-15"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Aurélien Tchouaméni",
+                "date_of_birth": "2000-01-27"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Marcus Thuram",
+                "date_of_birth": "1997-08-06"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Kylian Mbappé",
+                "date_of_birth": "1998-12-20"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Michael Olise",
+                "date_of_birth": "2001-12-12"
+            },
+            {
+                "number": 12,
+                "pos": "FW",
+                "name": "Bradley Barcola",
+                "date_of_birth": "2002-09-02"
+            },
+            {
+                "number": 13,
+                "pos": "MF",
+                "name": "N'Golo Kanté",
+                "date_of_birth": "1991-03-29"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Adrien Rabiot",
+                "date_of_birth": "1995-04-03"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Ibrahima Konaté",
+                "date_of_birth": "1999-05-25"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Mike Maignan",
+                "date_of_birth": "1995-07-03"
+            },
+            {
+                "number": 17,
+                "pos": "DF",
+                "name": "William Saliba",
+                "date_of_birth": "2001-03-24"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Warren Zaïre-Emery",
+                "date_of_birth": "2006-03-08"
+            },
+            {
+                "number": 19,
+                "pos": "DF",
+                "name": "Théo Hernandez",
+                "date_of_birth": "1997-10-06"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Désiré Doué",
+                "date_of_birth": "2005-06-03"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Lucas Hernandez",
+                "date_of_birth": "1996-02-14"
+            },
+            {
+                "number": 22,
+                "pos": "FW",
+                "name": "Jean-Philippe Mateta",
+                "date_of_birth": "1997-06-28"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Robin Risser",
+                "date_of_birth": "2004-12-02"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Rayan Cherki",
+                "date_of_birth": "2003-08-17"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Maghnes Akliouche",
+                "date_of_birth": "2002-02-25"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Maxence Lacroix",
+                "date_of_birth": "2000-04-06"
+            }
+        ]
+    },
+    {
+        "name": "Iraq",
+        "fifa_code": "IRQ",
+        "group": "I",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Fahad Talib",
+                "date_of_birth": "1994-10-21"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Rebin Sulaka",
+                "date_of_birth": "1992-04-12"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Hussein Ali",
+                "date_of_birth": "2002-03-01"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Zaid Tahseen",
+                "date_of_birth": "2001-01-29"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Akam Hashim",
+                "date_of_birth": "1998-08-16"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Manaf Younis",
+                "date_of_birth": "1996-11-16"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Youssef Amyn",
+                "date_of_birth": "2003-08-21"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Ibrahim Bayesh",
+                "date_of_birth": "2000-05-01"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Ali Al-Hamadi",
+                "date_of_birth": "2002-03-01"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Mohanad Ali",
+                "date_of_birth": "2000-06-20"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Ahmed Qasem",
+                "date_of_birth": "2003-07-12"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Jalal Hassan",
+                "date_of_birth": "1991-05-18"
+            },
+            {
+                "number": 13,
+                "pos": "FW",
+                "name": "Ali Yousif",
+                "date_of_birth": "1996-01-19"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Zidane Iqbal",
+                "date_of_birth": "2003-04-27"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Ahmed Maknzi",
+                "date_of_birth": "2001-09-24"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Amir Al-Ammari",
+                "date_of_birth": "1997-07-27"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Ali Jasim",
+                "date_of_birth": "2004-01-20"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Aymen Hussein",
+                "date_of_birth": "1996-03-22"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Kevin Yakob",
+                "date_of_birth": "2000-10-10"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Aimar Sher",
+                "date_of_birth": "2002-12-20"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Marko Farji",
+                "date_of_birth": "2004-03-16"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Ahmed Basil",
+                "date_of_birth": "1996-08-19"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Merchas Doski",
+                "date_of_birth": "1999-12-07"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Zaid Ismail",
+                "date_of_birth": "2002-01-03"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Mustafa Saadoon",
+                "date_of_birth": "2001-05-25"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Frans Putros",
+                "date_of_birth": "1993-07-14"
+            }
+        ]
+    },
+    {
+        "name": "Norway",
+        "fifa_code": "NOR",
+        "group": "I",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Ørjan Nyland",
+                "date_of_birth": "1990-09-10"
+            },
+            {
+                "number": 2,
+                "pos": "MF",
+                "name": "Morten Thorsby",
+                "date_of_birth": "1996-05-05"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Kristoffer Ajer",
+                "date_of_birth": "1998-04-17"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Leo Østigård",
+                "date_of_birth": "1999-11-28"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "David Møller Wolfe",
+                "date_of_birth": "2002-04-23"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Patrick Berg",
+                "date_of_birth": "1997-11-24"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Alexander Sørloth",
+                "date_of_birth": "1995-12-05"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Sander Berge",
+                "date_of_birth": "1998-02-14"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Erling Haaland",
+                "date_of_birth": "2000-07-21"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Martin Ødegaard",
+                "date_of_birth": "1998-12-17"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Jørgen Strand Larsen",
+                "date_of_birth": "2000-02-06"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Sander Tangvik",
+                "date_of_birth": "2002-11-29"
+            },
+            {
+                "number": 13,
+                "pos": "GK",
+                "name": "Egil Selvik",
+                "date_of_birth": "1997-07-30"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Fredrik Aursnes",
+                "date_of_birth": "1995-12-10"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Fredrik André Bjørkan",
+                "date_of_birth": "1998-08-21"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Marcus Holmgren Pedersen",
+                "date_of_birth": "2000-07-16"
+            },
+            {
+                "number": 17,
+                "pos": "DF",
+                "name": "Torbjørn Heggem",
+                "date_of_birth": "1999-01-12"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Kristian Thorstvedt",
+                "date_of_birth": "1999-03-13"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Thelo Aasgaard",
+                "date_of_birth": "2002-05-02"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Antonio Nusa",
+                "date_of_birth": "2005-04-17"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Andreas Schjelderup",
+                "date_of_birth": "2004-06-01"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Oscar Bobb",
+                "date_of_birth": "2003-07-12"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Jens Petter Hauge",
+                "date_of_birth": "1999-10-12"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Sondre Langås",
+                "date_of_birth": "2001-02-02"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Henrik Falchener",
+                "date_of_birth": "2003-05-08"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Julian Ryerson",
+                "date_of_birth": "1997-11-17"
+            }
+        ]
+    },
+    {
+        "name": "Senegal",
+        "fifa_code": "SEN",
+        "group": "I",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Yehvann Diouf",
+                "date_of_birth": "1999-11-16"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Mamadou Sarr",
+                "date_of_birth": "2005-08-29"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Kalidou Koulibaly",
+                "date_of_birth": "1991-06-20"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Abdoulaye Seck",
+                "date_of_birth": "1992-06-04"
+            },
+            {
+                "number": 5,
+                "pos": "MF",
+                "name": "Idrissa Gueye",
+                "date_of_birth": "1989-09-26"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Pathé Ciss",
+                "date_of_birth": "1994-03-16"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Assane Diao",
+                "date_of_birth": "2005-09-07"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Lamine Camara",
+                "date_of_birth": "2004-01-01"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Bamba Dieng",
+                "date_of_birth": "2000-03-23"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Sadio Mané",
+                "date_of_birth": "1992-04-10"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Nicolas Jackson",
+                "date_of_birth": "2001-06-20"
+            },
+            {
+                "number": 12,
+                "pos": "FW",
+                "name": "Cherif Ndiaye",
+                "date_of_birth": "1996-01-23"
+            },
+            {
+                "number": 13,
+                "pos": "FW",
+                "name": "Iliman Ndiaye",
+                "date_of_birth": "2000-03-06"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Ismail Jakobs",
+                "date_of_birth": "1999-08-17"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Krépin Diatta",
+                "date_of_birth": "1999-02-25"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Édouard Mendy",
+                "date_of_birth": "1992-03-01"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Pape Matar Sarr",
+                "date_of_birth": "2002-09-14"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Ismaïla Sarr",
+                "date_of_birth": "1998-02-25"
+            },
+            {
+                "number": 19,
+                "pos": "DF",
+                "name": "Moussa Niakhaté",
+                "date_of_birth": "1996-03-08"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Ibrahim Mbaye",
+                "date_of_birth": "2008-01-24"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Habib Diarra",
+                "date_of_birth": "2004-01-03"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Bara Sapoko Ndiaye",
+                "date_of_birth": "2007-12-31"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Mory Diaw",
+                "date_of_birth": "1993-06-22"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Antoine Mendy",
+                "date_of_birth": "2004-05-27"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "El Hadji Malick Diouf",
+                "date_of_birth": "2004-12-29"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Pape Gueye",
+                "date_of_birth": "1999-01-24"
+            }
+        ]
+    },
+    {
+        "name": "Algeria",
+        "fifa_code": "ALG",
+        "group": "J",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Melvin Mastil",
+                "date_of_birth": "2000-02-19"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Aïssa Mandi",
+                "date_of_birth": "1991-10-22"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Achref Abada",
+                "date_of_birth": "1999-06-15"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Mohamed Amine Tougai",
+                "date_of_birth": "2000-01-22"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Zineddine Belaïd",
+                "date_of_birth": "1999-03-20"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Ramiz Zerrouki",
+                "date_of_birth": "1998-05-26"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Riyad Mahrez",
+                "date_of_birth": "1991-02-21"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Houssem Aouar",
+                "date_of_birth": "1998-06-30"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Amine Gouiri",
+                "date_of_birth": "2000-02-16"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Farès Chaïbi",
+                "date_of_birth": "2002-11-28"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Anis Hadj Moussa",
+                "date_of_birth": "2002-02-11"
+            },
+            {
+                "number": 12,
+                "pos": "FW",
+                "name": "Nadhir Benbouali",
+                "date_of_birth": "2000-04-17"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Jaouen Hadjam",
+                "date_of_birth": "2003-03-26"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Hicham Boudaoui",
+                "date_of_birth": "1999-09-23"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Rayan Aït-Nouri",
+                "date_of_birth": "2001-06-06"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Oussama Benbot",
+                "date_of_birth": "1994-10-11"
+            },
+            {
+                "number": 17,
+                "pos": "DF",
+                "name": "Rafik Belghali",
+                "date_of_birth": "2002-06-07"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Mohamed Amoura",
+                "date_of_birth": "2000-05-09"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Nabil Bentaleb",
+                "date_of_birth": "1994-11-24"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Adil Boulbina",
+                "date_of_birth": "2003-05-02"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Ramy Bensebaini",
+                "date_of_birth": "1995-04-16"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Ibrahim Maza",
+                "date_of_birth": "2005-11-24"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Luca Zidane",
+                "date_of_birth": "1998-05-13"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Yacine Titraoui",
+                "date_of_birth": "2003-08-26"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Farès Ghedjemis",
+                "date_of_birth": "2002-09-06"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Samir Chergui",
+                "date_of_birth": "1999-02-06"
+            }
+        ]
+    },
+    {
+        "name": "Argentina",
+        "fifa_code": "ARG",
+        "group": "J",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Juan Musso",
+                "date_of_birth": "1994-05-06"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Nicolás Tagliafico",
+                "date_of_birth": "1992-08-31"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Gonzalo Montiel",
+                "date_of_birth": "1997-01-01"
+            },
+            {
+                "number": 5,
+                "pos": "MF",
+                "name": "Leandro Paredes",
+                "date_of_birth": "1994-06-29"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Lisandro Martínez",
+                "date_of_birth": "1998-01-18"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Rodrigo De Paul",
+                "date_of_birth": "1994-05-24"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Valentín Barco",
+                "date_of_birth": "2004-07-23"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Julián Alvarez",
+                "date_of_birth": "2000-01-31"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Lionel Messi",
+                "date_of_birth": "1987-06-24"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Giovani Lo Celso",
+                "date_of_birth": "1996-04-09"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Gerónimo Rulli",
+                "date_of_birth": "1992-05-20"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Cristian Romero",
+                "date_of_birth": "1998-04-27"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Exequiel Palacios",
+                "date_of_birth": "1998-10-05"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Nicolás González",
+                "date_of_birth": "1998-04-06"
+            },
+            {
+                "number": 16,
+                "pos": "FW",
+                "name": "Thiago Almada",
+                "date_of_birth": "2001-04-26"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Giuliano Simeone",
+                "date_of_birth": "2002-12-18"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Nico Paz",
+                "date_of_birth": "2004-09-08"
+            },
+            {
+                "number": 19,
+                "pos": "DF",
+                "name": "Nicolás Otamendi",
+                "date_of_birth": "1988-02-12"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Alexis Mac Allister",
+                "date_of_birth": "1998-12-24"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "José Manuel López",
+                "date_of_birth": "2000-12-06"
+            },
+            {
+                "number": 22,
+                "pos": "FW",
+                "name": "Lautaro Martínez",
+                "date_of_birth": "1997-08-22"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Emiliano Martínez",
+                "date_of_birth": "1992-09-02"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Enzo Fernández",
+                "date_of_birth": "2001-01-17"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Facundo Medina",
+                "date_of_birth": "1999-05-28"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Nahuel Molina",
+                "date_of_birth": "1998-04-06"
+            }
+        ]
+    },
+    {
+        "name": "Austria",
+        "fifa_code": "AUT",
+        "group": "J",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Alexander Schlager",
+                "date_of_birth": "1996-02-01"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "David Affengruber",
+                "date_of_birth": "2001-03-19"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Kevin Danso",
+                "date_of_birth": "1998-09-19"
+            },
+            {
+                "number": 4,
+                "pos": "MF",
+                "name": "Xaver Schlager",
+                "date_of_birth": "1997-09-28"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Stefan Posch",
+                "date_of_birth": "1997-05-14"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Nicolas Seiwald",
+                "date_of_birth": "2001-05-04"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Marko Arnautović",
+                "date_of_birth": "1989-04-19"
+            },
+            {
+                "number": 8,
+                "pos": "DF",
+                "name": "David Alaba",
+                "date_of_birth": "1992-06-24"
+            },
+            {
+                "number": 9,
+                "pos": "MF",
+                "name": "Marcel Sabitzer",
+                "date_of_birth": "1994-03-17"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Florian Grillitsch",
+                "date_of_birth": "1995-08-07"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Michael Gregoritsch",
+                "date_of_birth": "1994-04-18"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Florian Wiegele",
+                "date_of_birth": "2001-03-21"
+            },
+            {
+                "number": 13,
+                "pos": "GK",
+                "name": "Patrick Pentz",
+                "date_of_birth": "1997-01-02"
+            },
+            {
+                "number": 14,
+                "pos": "FW",
+                "name": "Saša Kalajdžić",
+                "date_of_birth": "1997-07-07"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Philipp Lienhart",
+                "date_of_birth": "1996-07-11"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Phillipp Mwene",
+                "date_of_birth": "1994-01-29"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Carney Chukwuemeka",
+                "date_of_birth": "2003-10-20"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Romano Schmid",
+                "date_of_birth": "2000-01-27"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Konrad Laimer",
+                "date_of_birth": "1997-05-27"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Patrick Wimmer",
+                "date_of_birth": "2001-05-30"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Alexander Prass",
+                "date_of_birth": "2001-05-26"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Marco Friedl",
+                "date_of_birth": "1998-03-16"
+            },
+            {
+                "number": 24,
+                "pos": "MF",
+                "name": "Paul Wanner",
+                "date_of_birth": "2005-12-23"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Michael Svoboda",
+                "date_of_birth": "1998-10-15"
+            },
+            {
+                "number": 26,
+                "pos": "MF",
+                "name": "Alessandro Schöpf",
+                "date_of_birth": "1994-02-07"
+            }
+        ]
+    },
+    {
+        "name": "Jordan",
+        "fifa_code": "JOR",
+        "group": "J",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Yazeed Abulaila",
+                "date_of_birth": "1993-01-08"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Mohammad Abu Hashish",
+                "date_of_birth": "1995-05-09"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Abdallah Nasib",
+                "date_of_birth": "1994-02-25"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Husam Abu Dahab",
+                "date_of_birth": "2000-05-13"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Yazan Al-Arab",
+                "date_of_birth": "1996-01-31"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Amer Jamous",
+                "date_of_birth": "2002-07-03"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Mohammad Abu Zrayq",
+                "date_of_birth": "1997-12-30"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Noor Al-Rawabdeh",
+                "date_of_birth": "1997-02-24"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Ali Olwan",
+                "date_of_birth": "2000-03-26"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Musa Al-Taamari",
+                "date_of_birth": "1997-06-10"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Odeh Al-Fakhouri",
+                "date_of_birth": "2005-11-22"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Nour Bani Attiah",
+                "date_of_birth": "1993-01-25"
+            },
+            {
+                "number": 13,
+                "pos": "FW",
+                "name": "Mahmoud Al-Mardi",
+                "date_of_birth": "1993-10-06"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Rajaei Ayed",
+                "date_of_birth": "1993-07-25"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Ibrahim Sadeh",
+                "date_of_birth": "2000-04-27"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Mo Abualnadi",
+                "date_of_birth": "2001-02-08"
+            },
+            {
+                "number": 17,
+                "pos": "DF",
+                "name": "Salim Obaid",
+                "date_of_birth": "1992-01-17"
+            },
+            {
+                "number": 19,
+                "pos": "DF",
+                "name": "Saed Al-Rosan",
+                "date_of_birth": "1997-02-01"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Mohannad Abu Taha",
+                "date_of_birth": "2003-02-02"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Nizar Al-Rashdan",
+                "date_of_birth": "1999-03-23"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Abdallah Al-Fakhouri",
+                "date_of_birth": "2000-01-22"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Ihsan Haddad",
+                "date_of_birth": "1994-02-05"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Ali Azaizeh",
+                "date_of_birth": "2004-04-13"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Mohammad Al-Dawoud",
+                "date_of_birth": "1992-04-12"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Anas Badawi",
+                "date_of_birth": "1997-09-13"
+            }
+        ]
+    },
+    {
+        "name": "Colombia",
+        "fifa_code": "COL",
+        "group": "K",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "David Ospina",
+                "date_of_birth": "1988-08-31"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Daniel Muñoz",
+                "date_of_birth": "1996-05-26"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Jhon Lucumí",
+                "date_of_birth": "1998-06-26"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Santiago Arias",
+                "date_of_birth": "1992-01-13"
+            },
+            {
+                "number": 5,
+                "pos": "MF",
+                "name": "Kevin Castaño",
+                "date_of_birth": "2000-09-29"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Richard Ríos",
+                "date_of_birth": "2000-06-02"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Luis Díaz",
+                "date_of_birth": "1997-01-13"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Jorge Carrascal",
+                "date_of_birth": "1998-05-25"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Jhon Córdoba",
+                "date_of_birth": "1993-05-11"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "James Rodríguez",
+                "date_of_birth": "1991-07-12"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Jhon Arias",
+                "date_of_birth": "1997-09-21"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Camilo Vargas",
+                "date_of_birth": "1989-03-09"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Yerry Mina",
+                "date_of_birth": "1994-09-23"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Gustavo Puerta",
+                "date_of_birth": "2003-07-23"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Juan Portilla",
+                "date_of_birth": "1998-09-12"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Jefferson Lerma",
+                "date_of_birth": "1994-10-25"
+            },
+            {
+                "number": 17,
+                "pos": "DF",
+                "name": "Johan Mojica",
+                "date_of_birth": "1992-08-21"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Willer Ditta",
+                "date_of_birth": "1998-01-23"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Cucho Hernández",
+                "date_of_birth": "1999-04-20"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Juan Fernando Quintero",
+                "date_of_birth": "1993-01-18"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Jaminton Campaz",
+                "date_of_birth": "2000-05-24"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Deiver Machado",
+                "date_of_birth": "1993-09-02"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Davinson Sánchez",
+                "date_of_birth": "1996-06-12"
+            },
+            {
+                "number": 24,
+                "pos": "GK",
+                "name": "Álvaro Montero",
+                "date_of_birth": "1995-03-29"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Luis Suárez",
+                "date_of_birth": "1997-12-02"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Andrés Gómez",
+                "date_of_birth": "2002-09-12"
+            }
+        ]
+    },
+    {
+        "name": "DR Congo",
+        "fifa_code": "COD",
+        "group": "K",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Lionel Mpasi",
+                "date_of_birth": "1994-08-01"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Aaron Wan-Bissaka",
+                "date_of_birth": "1997-11-26"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Steve Kapuadi",
+                "date_of_birth": "1998-04-30"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Axel Tuanzebe",
+                "date_of_birth": "1997-11-14"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Dylan Batubinsika",
+                "date_of_birth": "1996-02-15"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Ngal'ayel Mukau",
+                "date_of_birth": "2004-11-03"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Nathanaël Mbuku",
+                "date_of_birth": "2002-03-16"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Samuel Moutoussamy",
+                "date_of_birth": "1996-08-12"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Brian Cipenga",
+                "date_of_birth": "1998-03-11"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Théo Bongonda",
+                "date_of_birth": "1995-11-20"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Gaël Kakuta",
+                "date_of_birth": "1991-06-21"
+            },
+            {
+                "number": 12,
+                "pos": "DF",
+                "name": "Joris Kayembe",
+                "date_of_birth": "1994-08-08"
+            },
+            {
+                "number": 13,
+                "pos": "FW",
+                "name": "Meschak Elia",
+                "date_of_birth": "1997-08-06"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Noah Sadiki",
+                "date_of_birth": "2004-12-17"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Aaron Tshibola",
+                "date_of_birth": "1995-01-02"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Timothy Fayulu",
+                "date_of_birth": "1999-07-24"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Cédric Bakambu",
+                "date_of_birth": "1991-04-11"
+            },
+            {
+                "number": 18,
+                "pos": "MF",
+                "name": "Charles Pickel",
+                "date_of_birth": "1997-05-15"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Fiston Mayele",
+                "date_of_birth": "1994-06-24"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Yoane Wissa",
+                "date_of_birth": "1996-09-03"
+            },
+            {
+                "number": 21,
+                "pos": "GK",
+                "name": "Matthieu Epolo",
+                "date_of_birth": "2005-01-15"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Chancel Mbemba",
+                "date_of_birth": "1994-08-08"
+            },
+            {
+                "number": 23,
+                "pos": "FW",
+                "name": "Simon Banza",
+                "date_of_birth": "1996-08-13"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Gédéon Kalulu",
+                "date_of_birth": "1997-08-29"
+            },
+            {
+                "number": 25,
+                "pos": "MF",
+                "name": "Edo Kayembe",
+                "date_of_birth": "1998-06-03"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Arthur Masuaku",
+                "date_of_birth": "1993-11-07"
+            }
+        ]
+    },
+    {
+        "name": "Portugal",
+        "fifa_code": "POR",
+        "group": "K",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Diogo Costa",
+                "date_of_birth": "1999-09-19"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Nélson Semedo",
+                "date_of_birth": "1993-11-16"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Rúben Dias",
+                "date_of_birth": "1997-05-14"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Tomás Araújo",
+                "date_of_birth": "2002-05-16"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Diogo Dalot",
+                "date_of_birth": "1999-03-18"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Matheus Nunes",
+                "date_of_birth": "1998-08-27"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Cristiano Ronaldo",
+                "date_of_birth": "1985-02-05"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Bruno Fernandes",
+                "date_of_birth": "1994-09-08"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Gonçalo Ramos",
+                "date_of_birth": "2001-06-20"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Bernardo Silva",
+                "date_of_birth": "1994-08-10"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "João Félix",
+                "date_of_birth": "1999-11-10"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "José Sá",
+                "date_of_birth": "1993-01-17"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Renato Veiga",
+                "date_of_birth": "2003-07-29"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Gonçalo Inácio",
+                "date_of_birth": "2001-08-25"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "João Neves",
+                "date_of_birth": "2004-09-27"
+            },
+            {
+                "number": 16,
+                "pos": "FW",
+                "name": "Francisco Trincão",
+                "date_of_birth": "1999-12-29"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "Rafael Leão",
+                "date_of_birth": "1999-06-10"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Pedro Neto",
+                "date_of_birth": "2000-03-09"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Gonçalo Guedes",
+                "date_of_birth": "1996-11-29"
+            },
+            {
+                "number": 20,
+                "pos": "DF",
+                "name": "João Cancelo",
+                "date_of_birth": "1994-05-27"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Rúben Neves",
+                "date_of_birth": "1997-03-13"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Rui Silva",
+                "date_of_birth": "1994-02-07"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Vitinha",
+                "date_of_birth": "2000-02-13"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Samú Costa",
+                "date_of_birth": "2000-11-27"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Nuno Mendes",
+                "date_of_birth": "2002-06-19"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Francisco Conceição",
+                "date_of_birth": "2002-12-14"
+            }
+        ]
+    },
+    {
+        "name": "Uzbekistan",
+        "fifa_code": "UZB",
+        "group": "K",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Utkir Yusupov",
+                "date_of_birth": "1991-01-04"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Abdukodir Khusanov",
+                "date_of_birth": "2004-02-29"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Khojiakbar Alijonov",
+                "date_of_birth": "1997-04-19"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Farrukh Sayfiev",
+                "date_of_birth": "1991-01-17"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Rustam Ashurmatov",
+                "date_of_birth": "1996-07-07"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Akmal Mozgovoy",
+                "date_of_birth": "1999-04-02"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Otabek Shukurov",
+                "date_of_birth": "1996-06-22"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Jamshid Iskanderov",
+                "date_of_birth": "1993-10-16"
+            },
+            {
+                "number": 9,
+                "pos": "MF",
+                "name": "Odiljon Hamrobekov",
+                "date_of_birth": "1996-02-13"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Jaloliddin Masharipov",
+                "date_of_birth": "1993-09-01"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Oston Urunov",
+                "date_of_birth": "2000-12-19"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Abduvohid Nematov",
+                "date_of_birth": "2001-03-20"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Sherzod Nasrullaev",
+                "date_of_birth": "1998-07-23"
+            },
+            {
+                "number": 14,
+                "pos": "FW",
+                "name": "Eldor Shomurodov",
+                "date_of_birth": "1995-06-29"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Umar Eshmurodov",
+                "date_of_birth": "1992-11-30"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Botirali Ergashev",
+                "date_of_birth": "1995-06-23"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Dostonbek Khamdamov",
+                "date_of_birth": "1996-07-24"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Abdulla Abdullaev",
+                "date_of_birth": "1997-09-01"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Azizjon Ganiev",
+                "date_of_birth": "1998-02-22"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Azizbek Amonov",
+                "date_of_birth": "1997-10-30"
+            },
+            {
+                "number": 21,
+                "pos": "FW",
+                "name": "Igor Sergeev",
+                "date_of_birth": "1993-04-30"
+            },
+            {
+                "number": 22,
+                "pos": "MF",
+                "name": "Abbosbek Fayzullaev",
+                "date_of_birth": "2003-10-03"
+            },
+            {
+                "number": 23,
+                "pos": "MF",
+                "name": "Sherzod Esanov",
+                "date_of_birth": "2003-02-01"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Bekhruz Karimov",
+                "date_of_birth": "2007-08-07"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Avazbek Ulmasaliev",
+                "date_of_birth": "2000-03-27"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Jakhongir Urozov",
+                "date_of_birth": "2004-01-18"
+            }
+        ]
+    },
+    {
+        "name": "Croatia",
+        "fifa_code": "CRO",
+        "group": "L",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Dominik Livaković",
+                "date_of_birth": "1995-01-09"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Josip Stanišić",
+                "date_of_birth": "2000-04-02"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Marin Pongračić",
+                "date_of_birth": "1997-09-11"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Joško Gvardiol",
+                "date_of_birth": "2002-01-23"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Duje Ćaleta-Car",
+                "date_of_birth": "1996-09-17"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Josip Šutalo",
+                "date_of_birth": "2000-02-28"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "Nikola Moro",
+                "date_of_birth": "1998-03-12"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Mateo Kovačić",
+                "date_of_birth": "1994-05-06"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Andrej Kramarić",
+                "date_of_birth": "1991-06-19"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Luka Modrić",
+                "date_of_birth": "1985-09-09"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Ante Budimir",
+                "date_of_birth": "1991-07-22"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Ivor Pandur",
+                "date_of_birth": "2000-03-25"
+            },
+            {
+                "number": 13,
+                "pos": "MF",
+                "name": "Nikola Vlašić",
+                "date_of_birth": "1997-10-04"
+            },
+            {
+                "number": 14,
+                "pos": "FW",
+                "name": "Ivan Perišić",
+                "date_of_birth": "1989-02-02"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Mario Pašalić",
+                "date_of_birth": "1995-02-09"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Martin Baturina",
+                "date_of_birth": "2003-02-16"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Petar Sučić",
+                "date_of_birth": "2003-10-25"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Kristijan Jakić",
+                "date_of_birth": "1997-05-14"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Toni Fruk",
+                "date_of_birth": "2001-03-09"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Igor Matanović",
+                "date_of_birth": "2003-03-31"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Luka Sučić",
+                "date_of_birth": "2002-09-08"
+            },
+            {
+                "number": 22,
+                "pos": "DF",
+                "name": "Luka Vušković",
+                "date_of_birth": "2007-02-24"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "Dominik Kotarski",
+                "date_of_birth": "2000-02-10"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Marco Pašalić",
+                "date_of_birth": "2000-09-14"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Martin Erlić",
+                "date_of_birth": "1998-01-24"
+            },
+            {
+                "number": 26,
+                "pos": "FW",
+                "name": "Petar Musa",
+                "date_of_birth": "1998-03-04"
+            }
+        ]
+    },
+    {
+        "name": "England",
+        "fifa_code": "ENG",
+        "group": "L",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Jordan Pickford",
+                "date_of_birth": "1994-03-07"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Ezri Konsa",
+                "date_of_birth": "1997-10-23"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "Nico O'Reilly",
+                "date_of_birth": "2005-03-21"
+            },
+            {
+                "number": 4,
+                "pos": "MF",
+                "name": "Declan Rice",
+                "date_of_birth": "1999-01-14"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "John Stones",
+                "date_of_birth": "1994-05-28"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Marc Guéhi",
+                "date_of_birth": "2000-07-13"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Bukayo Saka",
+                "date_of_birth": "2001-09-05"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Elliot Anderson",
+                "date_of_birth": "2002-11-06"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Harry Kane",
+                "date_of_birth": "1993-07-28"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Jude Bellingham",
+                "date_of_birth": "2003-06-29"
+            },
+            {
+                "number": 11,
+                "pos": "FW",
+                "name": "Marcus Rashford",
+                "date_of_birth": "1997-10-31"
+            },
+            {
+                "number": 12,
+                "pos": "DF",
+                "name": "Tino Livramento",
+                "date_of_birth": "2002-11-12"
+            },
+            {
+                "number": 13,
+                "pos": "GK",
+                "name": "Dean Henderson",
+                "date_of_birth": "1997-03-12"
+            },
+            {
+                "number": 14,
+                "pos": "MF",
+                "name": "Jordan Henderson",
+                "date_of_birth": "1990-06-17"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Dan Burn",
+                "date_of_birth": "1992-05-09"
+            },
+            {
+                "number": 16,
+                "pos": "MF",
+                "name": "Kobbie Mainoo",
+                "date_of_birth": "2005-04-19"
+            },
+            {
+                "number": 17,
+                "pos": "MF",
+                "name": "Morgan Rogers",
+                "date_of_birth": "2002-07-26"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Anthony Gordon",
+                "date_of_birth": "2001-02-24"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Ollie Watkins",
+                "date_of_birth": "1995-12-30"
+            },
+            {
+                "number": 20,
+                "pos": "FW",
+                "name": "Noni Madueke",
+                "date_of_birth": "2002-03-10"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "Eberechi Eze",
+                "date_of_birth": "1998-06-29"
+            },
+            {
+                "number": 22,
+                "pos": "FW",
+                "name": "Ivan Toney",
+                "date_of_birth": "1996-03-16"
+            },
+            {
+                "number": 23,
+                "pos": "GK",
+                "name": "James Trafford",
+                "date_of_birth": "2002-10-10"
+            },
+            {
+                "number": 24,
+                "pos": "DF",
+                "name": "Reece James",
+                "date_of_birth": "1999-12-08"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Djed Spence",
+                "date_of_birth": "2000-08-09"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Jarell Quansah",
+                "date_of_birth": "2003-01-29"
+            }
+        ]
+    },
+    {
+        "name": "Ghana",
+        "fifa_code": "GHA",
+        "group": "L",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Lawrence Ati-Zigi",
+                "date_of_birth": "1996-11-29"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "Alidu Seidu",
+                "date_of_birth": "2000-06-04"
+            },
+            {
+                "number": 3,
+                "pos": "MF",
+                "name": "Caleb Yirenkyi",
+                "date_of_birth": "2006-01-15"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Jonas Adjetey",
+                "date_of_birth": "2003-12-13"
+            },
+            {
+                "number": 5,
+                "pos": "MF",
+                "name": "Thomas Partey",
+                "date_of_birth": "1993-06-13"
+            },
+            {
+                "number": 6,
+                "pos": "DF",
+                "name": "Abdul Mumin",
+                "date_of_birth": "1998-06-06"
+            },
+            {
+                "number": 7,
+                "pos": "FW",
+                "name": "Abdul Fatawu",
+                "date_of_birth": "2004-03-08"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Kwasi Sibo",
+                "date_of_birth": "1998-06-24"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Jordan Ayew",
+                "date_of_birth": "1991-09-11"
+            },
+            {
+                "number": 10,
+                "pos": "FW",
+                "name": "Brandon Thomas-Asante",
+                "date_of_birth": "1998-12-29"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Antoine Semenyo",
+                "date_of_birth": "2000-01-07"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "Joseph Anang",
+                "date_of_birth": "2000-06-08"
+            },
+            {
+                "number": 13,
+                "pos": "FW",
+                "name": "Christopher Bonsu Baah",
+                "date_of_birth": "2004-12-14"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Gideon Mensah",
+                "date_of_birth": "1998-07-18"
+            },
+            {
+                "number": 15,
+                "pos": "MF",
+                "name": "Elisha Owusu",
+                "date_of_birth": "1997-11-07"
+            },
+            {
+                "number": 16,
+                "pos": "GK",
+                "name": "Benjamin Asare",
+                "date_of_birth": "1992-07-13"
+            },
+            {
+                "number": 17,
+                "pos": "DF",
+                "name": "Abdul Rahman Baba",
+                "date_of_birth": "1994-07-02"
+            },
+            {
+                "number": 18,
+                "pos": "DF",
+                "name": "Jerome Opoku",
+                "date_of_birth": "1998-10-14"
+            },
+            {
+                "number": 19,
+                "pos": "FW",
+                "name": "Iñaki Williams",
+                "date_of_birth": "1994-06-15"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Augustine Boakye",
+                "date_of_birth": "2000-11-03"
+            },
+            {
+                "number": 21,
+                "pos": "DF",
+                "name": "Kojo Peprah Oppong",
+                "date_of_birth": "2004-06-04"
+            },
+            {
+                "number": 22,
+                "pos": "FW",
+                "name": "Kamaldeen Sulemana",
+                "date_of_birth": "2002-02-15"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Derrick Luckassen",
+                "date_of_birth": "1995-07-03"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Ernest Nuamah",
+                "date_of_birth": "2003-11-01"
+            },
+            {
+                "number": 25,
+                "pos": "FW",
+                "name": "Prince Kwabena Adu",
+                "date_of_birth": "2003-09-23"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Marvin Senaya",
+                "date_of_birth": "2001-01-28"
+            }
+        ]
+    },
+    {
+        "name": "Panama",
+        "fifa_code": "PAN",
+        "group": "L",
+        "players": [
+            {
+                "number": 1,
+                "pos": "GK",
+                "name": "Luis Mejía",
+                "date_of_birth": "1991-03-16"
+            },
+            {
+                "number": 2,
+                "pos": "DF",
+                "name": "César Blackman",
+                "date_of_birth": "1998-04-02"
+            },
+            {
+                "number": 3,
+                "pos": "DF",
+                "name": "José Córdoba",
+                "date_of_birth": "2001-06-03"
+            },
+            {
+                "number": 4,
+                "pos": "DF",
+                "name": "Fidel Escobar",
+                "date_of_birth": "1995-01-09"
+            },
+            {
+                "number": 5,
+                "pos": "DF",
+                "name": "Edgardo Fariña",
+                "date_of_birth": "2001-10-19"
+            },
+            {
+                "number": 6,
+                "pos": "MF",
+                "name": "Cristian Martínez",
+                "date_of_birth": "1997-02-06"
+            },
+            {
+                "number": 7,
+                "pos": "MF",
+                "name": "José Luis Rodríguez",
+                "date_of_birth": "1998-06-19"
+            },
+            {
+                "number": 8,
+                "pos": "MF",
+                "name": "Adalberto Carrasquilla",
+                "date_of_birth": "1998-11-28"
+            },
+            {
+                "number": 9,
+                "pos": "FW",
+                "name": "Tomás Rodríguez",
+                "date_of_birth": "1999-03-09"
+            },
+            {
+                "number": 10,
+                "pos": "MF",
+                "name": "Ismael Díaz",
+                "date_of_birth": "1997-05-12"
+            },
+            {
+                "number": 11,
+                "pos": "MF",
+                "name": "Yoel Bárcenas",
+                "date_of_birth": "1993-10-23"
+            },
+            {
+                "number": 12,
+                "pos": "GK",
+                "name": "César Samudio",
+                "date_of_birth": "1994-02-23"
+            },
+            {
+                "number": 13,
+                "pos": "DF",
+                "name": "Jiovany Ramos",
+                "date_of_birth": "1997-01-26"
+            },
+            {
+                "number": 14,
+                "pos": "DF",
+                "name": "Carlos Harvey",
+                "date_of_birth": "2000-02-03"
+            },
+            {
+                "number": 15,
+                "pos": "DF",
+                "name": "Eric Davis",
+                "date_of_birth": "1991-03-31"
+            },
+            {
+                "number": 16,
+                "pos": "DF",
+                "name": "Andrés Andrade",
+                "date_of_birth": "1998-10-16"
+            },
+            {
+                "number": 17,
+                "pos": "FW",
+                "name": "José Fajardo",
+                "date_of_birth": "1993-08-18"
+            },
+            {
+                "number": 18,
+                "pos": "FW",
+                "name": "Cecilio Waterman",
+                "date_of_birth": "1991-04-13"
+            },
+            {
+                "number": 19,
+                "pos": "MF",
+                "name": "Alberto Quintero",
+                "date_of_birth": "1987-12-18"
+            },
+            {
+                "number": 20,
+                "pos": "MF",
+                "name": "Aníbal Godoy",
+                "date_of_birth": "1990-02-10"
+            },
+            {
+                "number": 21,
+                "pos": "MF",
+                "name": "César Yanis",
+                "date_of_birth": "1996-01-28"
+            },
+            {
+                "number": 22,
+                "pos": "GK",
+                "name": "Orlando Mosquera",
+                "date_of_birth": "1994-12-25"
+            },
+            {
+                "number": 23,
+                "pos": "DF",
+                "name": "Michael Amir Murillo",
+                "date_of_birth": "1996-02-11"
+            },
+            {
+                "number": 24,
+                "pos": "FW",
+                "name": "Azarias Londoño",
+                "date_of_birth": "2001-06-21"
+            },
+            {
+                "number": 25,
+                "pos": "DF",
+                "name": "Roderick Miller",
+                "date_of_birth": "1992-04-03"
+            },
+            {
+                "number": 26,
+                "pos": "DF",
+                "name": "Jorge Gutiérrez",
+                "date_of_birth": "1998-09-01"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Adds `2026/worldcup.squads.json` with the final 26-player squads for all 48 teams of the 2026 FIFA World Cup: jersey number, position (GK/DF/MF/FW), name and date of birth — following the snake_case / `fifa_code` style of the other JSON datasets in this repo.

**Source:** Wikipedia — *2026 FIFA World Cup squads* (official FIFA squad lists), cross-checked against [api-football](https://www.api-football.com/).

**Summary:** 48 teams, 1245 players, all with a date of birth.

I know this repo is auto-generated from the upstream text — I also opened the matching text PR at openfootball/worldcup#83 (`more/2026_squads.txt`). Feel free to take whichever fits your build; happy to adjust the JSON shape to match a generator.

Contributed by **dPeluChe** ([dpeluche.dev](https://dpeluche.dev)). We built a free World Cup *quiniela* (prediction pool) app for Mexican fans — <https://iteris-mundialito.vercel.app/> — and wanted to give the squad data back. 🙌