### PR TITLE
Add match details for Mexico vs South Africa in 2026 World Cup

### DIFF
--- a/2026/worldcup.json
+++ b/2026/worldcup.json
@@ -5,6 +5,15 @@
     "time": "13:00 UTC-6",
     "team1": "Mexico",
     "team2": "South Africa",
+    "score": {
+      "ft": [2, 0],
+      "ht": [1, 0]
+    },
+    "goals1": [
+      {"name": "Julian Quiñones", "minute": 9},
+      {"name": "Raul Jiménez", "minute": 67}
+    ],
+    "goals2": [],
     "group": "Group A",
     "ground": "Mexico City"},
    {"round": "Matchday 1",


### PR DESCRIPTION
Included full-time and half-time scores, along with goal details for Mexico. This enhances the match data for Group A.